### PR TITLE
Turn off favicon in splash screen

### DIFF
--- a/core/classes/class.winbinder.php
+++ b/core/classes/class.winbinder.php
@@ -90,7 +90,7 @@ class WinBinder
         $window = $this->callWinBinder('wb_create_window', array($parent, $wclass, $caption, $xPos, $yPos, $width, $height, $style, $params));
 
         // Set tiny window icon
-        $this->setImage($window, $bearsamppCore->getResourcesPath() . '/icons/app.ico');
+        // $this->setImage($window, $bearsamppCore->getResourcesPath() . '/icons/app.ico');
 
         return $window;
     }

--- a/core/classes/class.winbinder.php
+++ b/core/classes/class.winbinder.php
@@ -410,8 +410,9 @@ class WinBinder
             $title == null ? $this->defaultTitle : $this->defaultTitle . ' - ' . $title, $type
         ));
 
+        // TODO why does this create an error?
         // Set tiny window icon
-        $this->setImage($messageBox, $bearsamppCore->getResourcesPath() . '/icons/app.ico');
+        //$this->setImage($messageBox, $bearsamppCore->getResourcesPath() . '/icons/app.ico');
 
         return $messageBox;
     }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- The PR addresses an issue where setting the window icon in the `messageBox` method was causing errors.
- The problematic line has been commented out, and a TODO has been added to investigate further.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.winbinder.php</strong><dd><code>Temporarily Disable Icon Setting in MessageBox to Avoid Errors</code></dd></summary>
<hr>
      
core/classes/class.winbinder.php

<li>Commented out the line setting the window icon in the <code>messageBox</code> <br>method to avoid errors.<br> <li> Added a TODO comment to investigate the source of the error.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/10/files#diff-07f9ebc2a2ff283ff4d24b630c1d831cfa2570a09c1f406a4330dbc6b81ae75f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

