### PR TITLE
fixes #361

### DIFF
--- a/core/resources/homepage/ajax/ajax.latestversion.php
+++ b/core/resources/homepage/ajax/ajax.latestversion.php
@@ -50,6 +50,5 @@ if (version_compare($bearsamppCurrentVersion, $bearsamppLatestVersion, '<')) {
     $result['display'] = true;
     $result['download'] .= '<a role="button" class="btn btn-success fullversionurl" href="' . $latestVersionUrl . '" target="_blank"><i class="fa fa-download"></i> ';
     $result['download'] .= $bearsamppLang->getValue(Lang::DOWNLOAD) . ' <strong>' . APP_TITLE . ' ' . $bearsamppLatestVersion . '</strong><br />';
-    $result['download'] .= '<small>bearsampp-' . $bearsamppLatestVersion . '.7z</small></a>';
 }
 echo json_encode($result);


### PR DESCRIPTION
### **PR Type**
bug_fix

[#361](https://github.com/Bearsampp/Bearsampp/issues/361)
___

### **Description**
- Removed a redundant line that displayed the download link for the latest version in `ajax.latestversion.php`. This simplifies the download section and avoids unnecessary clutter.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ajax.latestversion.php</strong><dd><code>Remove Redundant Download Link Display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
core/resources/homepage/ajax/ajax.latestversion.php

- Removed redundant download link display for the latest version.



</details>
    

  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/15/files#diff-e833b84f35288e2d942d1663dda4f1d3ce4c24f04480c89e1c9bd854da176fed">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

