### PR TITLE
Fixing Pop Up Update Link

### DIFF
--- a/core/classes/tpls/class.tpl.aestan.php
+++ b/core/classes/tpls/class.tpl.aestan.php
@@ -99,7 +99,6 @@ class TplAestan
     {
         global $bearsamppRoot, $bearsamppConfig;
 
-        $link = '';
         if ($local) {
             $link = $bearsamppRoot->getLocalUrl($link);
         }


### PR DESCRIPTION
### **User description**
Sorry. I added a $link = '', because phpstorm said it was not defined, I didn't notice it was a parameter. Removed and tested.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed an unnecessary initialization of the `$link` variable in the `getItemLink` method.
- Ensured the `$link` parameter is used correctly as intended, fixing potential issues with link generation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.tpl.aestan.php</strong><dd><code>Fix unnecessary initialization of `$link` variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
core/classes/tpls/class.tpl.aestan.php

<li>Removed unnecessary initialization of the <code>$link</code> variable.<br> <li> Ensured <code>$link</code> parameter is used correctly as intended.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/25/files#diff-c0e7fcbed80ac0bf9d0d8a678595db3eb1c3372db864496f82b2a829cc4632a6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

