### PR TITLE
Update class.tpl.aestan.php to revert previous change

### DIFF
--- a/core/classes/tpls/class.tpl.aestan.php
+++ b/core/classes/tpls/class.tpl.aestan.php
@@ -99,7 +99,6 @@ class TplAestan
     {
         global $bearsamppRoot, $bearsamppConfig;
 
-        $link = '';
         if ($local) {
             $link = $bearsamppRoot->getLocalUrl($link);
         }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in the `getItemLink` method where the `$link` variable was incorrectly set to an empty string, causing localhost links to not work.
- Ensured that the `$link` variable is only modified if the `$local` parameter is true.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.tpl.aestan.php</strong><dd><code>Revert incorrect link initialization in `getItemLink` method</code></dd></summary>
<hr>
      
core/classes/tpls/class.tpl.aestan.php

<li>Removed the line that sets <code>$link</code> to an empty string.<br> <li> Ensured that the <code>$link</code> variable is only modified if <code>$local</code> is true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/26/files#diff-c0e7fcbed80ac0bf9d0d8a678595db3eb1c3372db864496f82b2a829cc4632a6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

