### PR TITLE
Add Bruno download link and version badge to homepage summary template Fixes #88

### DIFF
--- a/core/resources/homepage/tpls/hp.summary.html
+++ b/core/resources/homepage/tpls/hp.summary.html
@@ -1,9 +1,10 @@
 <!--
-  ~ Copyright (c) 2021-2024 Bearsampp
-  ~ License:  GNU General Public License version 3 or later; see LICENSE.txt
-  ~ Author: Bear
-  ~ Website: https://bearsampp.com
-  ~ Github: https://github.com/Bearsampp
+  ~ /*
+  ~  * Copyright (c) 2021-2024 Bearsampp
+  ~  * License:  GNU General Public License version 3 or later; see LICENSE.txt
+  ~  * Website: https://bearsampp.com
+  ~  * Github: https://github.com/Bearsampp
+  ~  */
   -->
 
 <div class = "row summary">
@@ -99,7 +100,16 @@
             </div>
             <div class = "card-body card-summary">
                 <div class = "list-group" style = "margin-bottom:0;">
-          <span class = "list-group-item">
+                    <span class = "list-group-item">
+            <a aria-label = "Download Bruno" href = "<?php echo Util::getWebsiteUrl('module/bruno', '#releases'); ?>" target = "_blank"
+               title = "<?php echo $downloadTitle; ?>">
+                <span class = "float-end ms-2"><i class = "fa-solid fa-cloud-arrow-down"></i>
+                </span>
+            </a>
+            <span class = "float-end badge text-bg-primary"><?php echo $bearsamppTools->getBruno()->getVersion(); ?></span>
+            <span><?php echo $bearsamppLang->getValue(Lang::BRUNO); ?></span>
+          </span>
+                    <span class = "list-group-item">
             <a aria-label = "Download Composer" href = "<?php echo Util::getWebsiteUrl('module/composer', '#releases'); ?>" target = "_blank"
                title = "<?php echo $downloadTitle; ?>">
                 <span class = "float-end ms-2"><i class = "fa-solid fa-cloud-arrow-down"></i>


### PR DESCRIPTION
### **User description**
Fixes #88


___

### **PR Type**
enhancement


___

### **Description**
- Added a download link for Bruno on the homepage summary template, allowing users to easily access the Bruno module.
- Introduced a version badge next to the Bruno download link to display the current version.
- Updated the formatting of HTML comments for better readability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hp.summary.html</strong><dd><code>Add Bruno download link and version badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/resources/homepage/tpls/hp.summary.html

<li>Added a download link for Bruno with an icon.<br> <li> Introduced a version badge for Bruno.<br> <li> Updated HTML comment formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/89/files#diff-0bf0168c98b6044e05d4bda06c9dce8474790256c9b751b14285b5271fb5f284">+16/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information