### PR TITLE
correct app.ico error generated by faulty window identifier per https://github.com/crispy-computing-machine/Winbinder-Examples/issues/1#issuecomment-2569378674

### DIFF
--- a/core/classes/class.core.php
+++ b/core/classes/class.core.php
@@ -117,7 +117,7 @@ class Core
     {
         global $bearsamppCore;
 
-        return $bearsamppCore->getResourcesPath( $aetrayPath ) . '/homepage/img/icons';
+        return $bearsamppCore->getResourcesPath( $aetrayPath ) . '/homepage/img/icons/';
     }
 
     /**
@@ -131,7 +131,7 @@ class Core
     {
         global $bearsamppCore;
 
-        return $bearsamppCore->getResourcesPath( $aetrayPath ) . '/homepage/img';
+        return $bearsamppCore->getResourcesPath( $aetrayPath ) . '/homepage/img/';
     }
 
     /**

--- a/core/classes/class.winbinder.php
+++ b/core/classes/class.winbinder.php
@@ -143,7 +143,7 @@ class WinBinder
         $window  = $this->callWinBinder('wb_create_window', array($parent, $wclass, $caption, $xPos, $yPos, $width, $height, $style, $params));
 
         // Set tiny window icon
-        $this->setImage($window, $bearsamppCore->getIconsPath() . '/app.ico');
+        $this->setImage($window, $bearsamppCore->getIconsPath() . 'app.ico');
 
         return $window;
     }
@@ -934,26 +934,6 @@ class WinBinder
             $title == null ? $this->defaultTitle : $this->defaultTitle . ' - ' . $title,
             $type
         ));
-
-        // TODO why does this create an error sometimes.
-        // Set tiny window icon
-        // Ensure $messageBox is not null
-        if ($messageBox === null) {
-            error_log('Error: $messageBox is null.');
-
-            return;
-        }
-
-        // Ensure the icon path is correct and the file exists
-        $iconPath = $bearsamppCore->getIconsPath() . '/app.ico';
-        if (!file_exists($iconPath)) {
-            error_log('Error: Icon file does not exist at path: ' . $iconPath);
-
-            return;
-        }
-
-        // Call the setImage method
-        $this->setImage($messageBox, $iconPath);
 
         return $messageBox;
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect path concatenation for icons and images.

- Corrected the icon path used in `createWindow` method.

- Removed redundant and error-prone code in `messageBox` method.

- Improved code reliability by addressing faulty window identifier issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.core.php</strong><dd><code>Corrected path concatenation for icons and images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.core.php

<li>Fixed path concatenation for icons and images.<br> <li> Added trailing slashes to paths for consistency.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/94/files#diff-054c1637f705cfc626b10bb80e0d3869e005dbc4663eb468305bf1507e95e888">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.winbinder.php</strong><dd><code>Fixed icon path and removed redundant code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.winbinder.php

<li>Corrected icon path in <code>createWindow</code> method.<br> <li> Removed redundant error-checking code in <code>messageBox</code>.<br> <li> Improved error handling and code clarity.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/94/files#diff-07f9ebc2a2ff283ff4d24b630c1d831cfa2570a09c1f406a4330dbc6b81ae75f">+1/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information