### PR TITLE
corrects issue where date of last quickpick.json was not checked properly. adds autologger for header when logsverbose is set to 2 ( 'debug')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@
 !/core/tmp/.gitignore
 .codiumai
 /core/resources/quickpick-releases.json
+
+.qodo

--- a/core/classes/actions/class.action.quickPick.php
+++ b/core/classes/actions/class.action.quickPick.php
@@ -117,6 +117,8 @@ class QuickPick
      */
     public function checkQuickpickJson()
     {
+		global $bearsamppConfig;
+
         // Initialize variables
         $localFileCreationTime = 0;
 
@@ -130,11 +132,17 @@ class QuickPick
 
         // Get the creation time of the remote file
         $headers = get_headers( QUICKPICK_JSON_URL, 1 );
-        if ( $headers === false || !isset( $headers['Last-Modified'] ) ) {
-            // If we cannot get the headers or Last-Modified is not set, assume no update is needed
+
+		// Log the headers for debugging purposes
+        if ( $bearsamppConfig->getLogsVerbose() === 2) {
+            Util::logDebug('Headers: ' . print_r($headers, true));
+        }
+
+        if ( $headers === false || !isset( $headers['Date'] ) ) {
+            // If we cannot get the headers or Date is not set, assume no update is needed
             return false;
         }
-        $remoteFileCreationTime = strtotime( $headers['Last-Modified'] );
+        $remoteFileCreationTime = strtotime( $headers['Date'] );
 
         // Compare the creation times
         if ( $remoteFileCreationTime > $localFileCreationTime || $localFileCreationTime === 0 ) {

--- a/core/classes/actions/class.action.quickPick.php
+++ b/core/classes/actions/class.action.quickPick.php
@@ -133,10 +133,8 @@ class QuickPick
         $this->logHeaders($headers);
 
         // Compare the creation times (remote vs. local)
-        $remoteFileCreationTime = strtotime($headers['Date'] ?? '');
-        if ($remoteFileCreationTime > $localFileCreationTime) {
-            return $this->rebuildQuickpickJson();
-        }
+        $remoteFileCreationTime = strtotime(isset($headers['Date']) ? $headers['Date'] : '');
+		if ($remoteFileCreationTime > $localFileCreationTime) { return $this->rebuildQuickpickJson(); }
 
         // Return false if local file is already up-to-date
         return false;

--- a/core/classes/actions/class.action.quickPick.php
+++ b/core/classes/actions/class.action.quickPick.php
@@ -107,7 +107,7 @@ class QuickPick
     /**
      * Checks if the local `quickpick-releases.json` file is up-to-date with the remote version.
      *
-     * This method compares the creation time of the local JSON file with the remote file's last modified time.
+     * Compares the creation time of the local JSON file with the remote file's last modified time.
      * If the remote file is newer or the local file does not exist, it fetches the latest JSON data by calling
      * the `rebuildQuickpickJson` method.
      *
@@ -117,40 +117,73 @@ class QuickPick
      */
     public function checkQuickpickJson()
     {
-		global $bearsamppConfig;
+        global $bearsamppConfig;
 
-        // Initialize variables
-        $localFileCreationTime = 0;
+        // Determine local file creation time or rebuild if missing
+        $localFileCreationTime = $this->getLocalFileCreationTime();
 
-        // Get the creation time of the local file if it exists
-        if ( file_exists( $this->jsonFilePath ) ) {
-            $localFileCreationTime = filectime( $this->jsonFilePath );
-        }
-        else {
-            $result = $this->rebuildQuickpickJson();
-        }
-
-        // Get the creation time of the remote file
-        $headers = get_headers( QUICKPICK_JSON_URL, 1 );
-
-		// Log the headers for debugging purposes
-        if ( $bearsamppConfig->getLogsVerbose() === 2) {
-            Util::logDebug('Headers: ' . print_r($headers, true));
-        }
-
-        if ( $headers === false || !isset( $headers['Date'] ) ) {
-            // If we cannot get the headers or Date is not set, assume no update is needed
+        // Attempt to retrieve remote file headers
+        $headers = get_headers(QUICKPICK_JSON_URL, 1);
+        if (!$this->isValidHeaderResponse($headers)) {
+            // If headers or Date are invalid, assume no update needed
             return false;
         }
-        $remoteFileCreationTime = strtotime( $headers['Date'] );
 
-        // Compare the creation times
-        if ( $remoteFileCreationTime > $localFileCreationTime || $localFileCreationTime === 0 ) {
+        // Optionally log headers for verbose output
+        $this->logHeaders($headers);
+
+        // Compare the creation times (remote vs. local)
+        $remoteFileCreationTime = strtotime($headers['Date'] ?? '');
+        if ($remoteFileCreationTime > $localFileCreationTime) {
             return $this->rebuildQuickpickJson();
         }
 
-        // Return false if the local file is up-to-date
+        // Return false if local file is already up-to-date
         return false;
+    }
+
+    /**
+     * Returns the local file's creation time, or triggers and returns 0 if file does not exist.
+     *
+     * @return int Local file's creation time or 0 if the file doesn't exist.
+     */
+    private function getLocalFileCreationTime()
+    {
+        if (!file_exists($this->jsonFilePath)) {
+            // If local file is missing, rebuild it immediately
+            $this->rebuildQuickpickJson();
+            return 0;
+        }
+        return filectime($this->jsonFilePath);
+    }
+
+    /**
+     * Determines whether the header response is valid and includes a 'Date' key.
+     *
+     * @param mixed $headers Headers retrieved from get_headers().
+     * @return bool True if headers are valid and contain 'Date', false otherwise.
+     */
+    private function isValidHeaderResponse($headers): bool
+    {
+        // If headers retrieval failed or Date is not set, return false
+        if ($headers === false || !isset($headers['Date'])) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Logs the headers in debug mode if logsVerbose is set to 2.
+     *
+     * @param array $headers The headers returned by get_headers().
+     */
+    private function logHeaders(array $headers): void
+    {
+        global $bearsamppConfig;
+
+        if ($bearsamppConfig->getLogsVerbose() === 2) {
+            Util::logDebug('Headers: ' . print_r($headers, true));
+        }
     }
 
     /**


### PR DESCRIPTION
### **User description**
Check for existence of "bruno 1.38.1" or a new module release in localhost.
Verify it doesn't exist.
apply this pr
refresh localhost
verify that bruno 1.38.1 or new module now exists.
issue: https://github.com/Bearsampp/Bearsampp/issues/500


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed issue with improper date check in `quickpick.json`.

- Added logging of headers when `logsverbose` is set to debug level.

- Updated to use `Date` header instead of `Last-Modified`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.action.quickPick.php</strong><dd><code>Fix date check and add debug logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/actions/class.action.quickPick.php

<li>Fixed the date check logic for <code>quickpick.json</code>.<br> <li> Added global <code>bearsamppConfig</code> for configuration access.<br> <li> Introduced debug-level logging for HTTP headers.<br> <li> Replaced <code>Last-Modified</code> with <code>Date</code> header for remote file checks.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/95/files#diff-d1f6e26b10d84a231fa30e52206aab0eb80b30eb4a24c22c2fabefb20384ba61">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>