### PR TITLE
Add required empty owner and event_type fields in workflow dispatch

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -21,3 +21,5 @@ jobs:
                   repo: Bearsampp/Bearsampp
                   # Required when using the `repo` option. Either a PAT or a token generated from the GitHub app or CLI
                   token: "${{ secrets.GH_PAT }}"
+                  owner: ''
+                  event_type: ''


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added required empty `owner` and `event_type` fields in workflow dispatch.

- Ensures compatibility and proper configuration for the dispatcher workflow.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dispatcher.yml</strong><dd><code>Add empty `owner` and `event_type` fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dispatcher.yml

<li>Added an empty <code>owner</code> field to the workflow dispatcher configuration.<br> <li> Added an empty <code>event_type</code> field to the workflow dispatcher <br>configuration.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/99/files#diff-2b9e1384af32e288c5a479276b8fe4d974d717ef28e426c3f98839107715ea42">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>