### PR TITLE
🔧 Simplify destroyWindow method with direct exit call for cleaner termination reverts new method

### DIFF
--- a/core/classes/class.winbinder.php
+++ b/core/classes/class.winbinder.php
@@ -1,8 +1,8 @@
 <?php
 /*
  *
- *  * Copyright (c) 2021-2024 Bearsampp
- *  * License:  GNU General Public License version 3 or later; see LICENSE.txt
+ *  * Copyright (c) 2022-2025 Bearsampp
+ *  * License: GNU General Public License version 3 or later; see LICENSE.txt
  *  * Website: https://bearsampp.com
  *  * Github: https://github.com/Bearsampp
  *
@@ -213,60 +213,14 @@ class WinBinder
     }
 
     /**
-     * Destroys a window with proper cleanup and handling.
+     * Destroys a window.
      *
      * @param   mixed  $window  The window object to destroy.
-     * @return  boolean True if window was successfully destroyed
      */
     public function destroyWindow($window)
     {
-        // Check if window exists and is valid
-        if (!$window || !$this->windowIsValid($window)) {
-            return true; // Already closed or invalid window
-        }
-
-        // Get window title before destruction for fallback
-        $windowTitle = $this->getText($window);
-        $currentPid = Win32Ps::getCurrentPid();
-
-        // Attempt standard destruction
-        $this->callWinBinder('wb_destroy_window', array($window));
-
-        // Verify closure with retries
-        $maxAttempts = 3;
-        $attempt     = 0;
-        $destroyed   = false;
-
-        while ($attempt < $maxAttempts && !$destroyed) {
-            $this->processMessages();
-            usleep(100000); // 100ms delay
-            $destroyed = !$this->windowIsValid($window);
-            $attempt++;
-        }
-
-        // Fallback to process termination if window still exists
-        if (!$destroyed) {
-            // 1. Try to close using window title
-            $this->exec('taskkill', '/FI "WINDOWTITLE eq ' . $windowTitle . '" /F', true);
-
-            // 2. Try to kill process directly using Winbinder's PID method
-            $currentPid = Win32Ps::getCurrentPid();
-            if (!empty($currentPid)) {
-                $this->exec('taskkill', '/PID ' . $currentPid . ' /T /F', true);
-                $this->writeLog('Force-killed PID: ' . $currentPid . ' for window: ' . $window);
-            }
-            
-            // 3. Final sanity check
-            if ($this->windowIsValid($window)) {
-                $this->callWinBinder('wb_destroy_window', array($window), true); // Force native call
-            }
-            
-            // 4. Reset internal state to prevent memory leaks
-            $this->reset();
-        }
-
-        // Final verification
-        return !$this->windowIsValid($window);
+        $this->callWinBinder('wb_destroy_window', array($window), true);
+        exit();
     }
 
     /**


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified the `destroyWindow` method for direct termination.

- Removed extensive validation and fallback mechanisms in `destroyWindow`.

- Updated copyright information in the file header.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.winbinder.php</strong><dd><code>Simplified `destroyWindow` method and updated header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.winbinder.php

<li>Simplified the <code>destroyWindow</code> method by removing validation and <br>fallback logic.<br> <li> Added a direct <code>exit()</code> call after invoking <code>wb_destroy_window</code>.<br> <li> Updated copyright years in the file header.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/131/files#diff-07f9ebc2a2ff283ff4d24b630c1d831cfa2570a09c1f406a4330dbc6b81ae75f">+5/-51</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>