### PR TITLE
🔧 Optimize PHP configuration by removing deprecated directives and increasing memory limit to 256MB

### DIFF
--- a/core/libs/php/php.ini
+++ b/core/libs/php/php.ini
@@ -1,24 +1,14 @@
 ; PHP 8.2.3
 
 ; Global config/security/performance
-;zend.enable_gc = 1
 date.timezone = "America/Chicago"
 max_execution_time = 30
-allow_url_fopen = 1
 allow_url_include = 0
-register_globals = 0
-default_socket_timeout = 60
-safe_mode = 0
-safe_mode_gid = 0
-expose_php = 1
 phar.readonly = 0
-default_charset = "UTF-8"
 post_max_size = 32M
-memory_limit = 128M
-max_input_time = 60
+memory_limit = 256M
 
 ; Error logging
-error_reporting=E_ALL
 display_errors = 1
 display_startup_errors = 1
 log_errors = 1
@@ -40,7 +30,6 @@ extension=php_openssl.dll
 extension=php_pgsql.dll
 ;extension=php_zip.dll
 
-
 ; Windows
 extension=php_winbinder.dll
 extension=php_win32ps.dll
@@ -53,7 +42,6 @@ extension=php_win32std.dll
 ;xdebug.mode = profile;
 ;xdebug.profiler_output_name = "callgrind.out.%t.%p"
 ;xdebug.output_dir = ".\"
-;zend.enable_gc = 0
 
 ; asset unit tests
 assert.exception=1


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed deprecated and unnecessary PHP directives for optimization.

- Increased `memory_limit` from 128MB to 256MB for better performance.

- Cleaned up redundant or obsolete configuration entries.

- Retained essential directives for error logging and debugging.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>PHP configuration optimized and memory limit increased</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/libs/php/php.ini

<li>Removed deprecated directives like <code>register_globals</code> and <code>safe_mode</code>.<br> <li> Increased <code>memory_limit</code> to 256MB for improved performance.<br> <li> Cleaned up redundant entries such as <code>zend.enable_gc</code> and <br><code>default_charset</code>.<br> <li> Retained critical settings for error logging and debugging.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/138/files#diff-253c85b62e95af36e887ed890502d4a76f4dcfffd93efb0ef0afa60174bf72ca">+1/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>