### PR TITLE
typo in .conf for quickpick pr

### DIFF
--- a/core/classes/class.config.php
+++ b/core/classes/class.config.php
@@ -23,7 +23,7 @@ class Config
     const CFG_NOTEPAD = 'notepad';
     const CFG_SCRIPTS_TIMEOUT = 'scriptsTimeout';
     const DOWNLOAD_ID = 'DownloadId';
-    const INCLUDE_PR = 'IncludePR';
+    const INCLUDE_PR = 'IncludePr';
 
     const CFG_DEFAULT_LANG = 'defaultLang';
     const CFG_HOSTNAME = 'hostname';


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected a typo in the `INCLUDE_PR` constant name

- Ensures consistent naming for configuration constants


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.config.php</strong><dd><code>Fix typo in INCLUDE_PR constant name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.config.php

<li>Renamed constant <code>INCLUDE_PR</code> to <code>INCLUDE_Pr</code> to fix casing typo.<br> <li> Aligns constant name with intended configuration key.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/151/files#diff-61cd0e62f75dc024d9e896fd094cb81b2d4b232c9e90e4308563c4d12bb40e9f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>