### PR TITLE
fix phpinfo not displaying

### DIFF
--- a/core/resources/homepage/homepage.php
+++ b/core/resources/homepage/homepage.php
@@ -178,18 +178,18 @@ $getLoader = '<span class = "loader float-end"><img src = "' . $imagesPath . 'lo
 <div id = "page-wrapper">
     <?php 
     try {
-        include 'tpls/hp.latestversion.html';
+        include __DIR__ . '/tpls/hp.latestversion.html';
     } catch (Exception $e) {
         error_log('Error including latest version template: ' . $e->getMessage());
         echo '<div class="alert alert-warning">Latest version information unavailable</div>';
     }
 
     try {
-        $pagePath = 'tpls/hp.' . $bearsamppHomepage->getPage() . '.html';
+        $pagePath = __DIR__ . '/tpls/hp.' . $bearsamppHomepage->getPage() . '.html';
         if (file_exists($pagePath)) {
             include $pagePath;
         } else {
-            include 'tpls/hp.index.html';
+            include __DIR__ . '/tpls/hp.index.html';
         }
     } catch (Exception $e) {
         error_log('Error including page template: ' . $e->getMessage());

--- a/core/resources/homepage/homepage.php
+++ b/core/resources/homepage/homepage.php
@@ -185,8 +185,9 @@ $getLoader = '<span class = "loader float-end"><img src = "' . $imagesPath . 'lo
     }
 
     try {
-        $pagePath = __DIR__ . '/tpls/hp.' . $bearsamppHomepage->getPage() . '.html';
-        if (file_exists($pagePath)) {
+        $page = preg_replace('/[^a-z0-9_-]/i', '', (string) $bearsamppHomepage->getPage());
+        $pagePath = __DIR__ . '/tpls/hp.' . $page . '.html';
+        if (is_file($pagePath)) {
             include $pagePath;
         } else {
             include __DIR__ . '/tpls/hp.index.html';


### PR DESCRIPTION
### **User description**
use phpinfo link on root page.  phpinfo should displa


___

### **PR Type**
Bug fix


___

### **Description**
- Fix file inclusion paths using `__DIR__` constant

- Add input sanitization for page parameter

- Replace `file_exists()` with `is_file()` for security


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Relative paths"] --> B["Absolute paths with __DIR__"]
  C["Unsanitized input"] --> D["Sanitized page parameter"]
  E["file_exists()"] --> F["is_file() check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>homepage.php</strong><dd><code>Fix file paths and add input validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/resources/homepage/homepage.php

<ul><li>Replace relative paths with absolute paths using <code>__DIR__</code><br> <li> Add regex sanitization for page parameter input<br> <li> Change <code>file_exists()</code> to <code>is_file()</code> for better security<br> <li> Maintain error handling for file inclusion failures</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/163/files#diff-6cc98c81a488b7ab55165d28cb3ad20a7f60cb1d4edcf2d97d889b99a3f4aae0">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

