### PR TITLE
Fix PHP 8.4+ compatibility issues for memcached, MySQL, and cURL

### DIFF
--- a/core/classes/actions/class.action.quickPick.php
+++ b/core/classes/actions/class.action.quickPick.php
@@ -30,7 +30,6 @@ class QuickPick
         'Apache'      => ['type' => 'binary'],
         'Bruno'       => ['type' => 'tools'],
         'Composer'    => ['type' => 'tools'],
-        'PowerShell'  => ['type' => 'tools'],
         'Ghostscript' => ['type' => 'tools'],
         'Git'         => ['type' => 'tools'],
         'Mailpit'     => ['type' => 'binary'],
@@ -44,6 +43,7 @@ class QuickPick
         'PhpMyAdmin'  => ['type' => 'application'],
         'PhpPgAdmin'  => ['type' => 'application'],
         'PostgreSQL'  => ['type' => 'binary'],
+        'PowerShell'  => ['type' => 'tools'],
         'Python'      => ['type' => 'tools'],
         'Ruby'        => ['type' => 'tools'],
         'Xlight'      => ['type' => 'binary']

--- a/core/classes/bins/class.bin.mysql.php
+++ b/core/classes/bins/class.bin.mysql.php
@@ -252,10 +252,18 @@ class BinMysql extends Module
 
         if ($cachedConnection === null || $lastPort !== $port) {
             try {
+                // Use new constant name for PHP 8.5+ while maintaining backward compatibility
+                // Check PHP version to avoid deprecation warnings
+                if (PHP_VERSION_ID >= 80500) {
+                    $initCommandAttr = \Pdo\Mysql::ATTR_INIT_COMMAND;
+                } else {
+                    $initCommandAttr = \PDO::MYSQL_ATTR_INIT_COMMAND;
+                }
+
                 $options = [
                     \PDO::ATTR_TIMEOUT => $timeout,
                     \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-                    \PDO::MYSQL_ATTR_INIT_COMMAND => "SET SESSION sql_mode=''"
+                    $initCommandAttr => "SET SESSION sql_mode=''"
                 ];
 
                 $dsn = 'mysql:host=127.0.0.1;port=' . $port;
@@ -436,10 +444,18 @@ class BinMysql extends Module
         }
 
         try {
+            // Use new constant name for PHP 8.5+ while maintaining backward compatibility
+            // Check PHP version to avoid deprecation warnings
+            if (PHP_VERSION_ID >= 80500) {
+                $initCommandAttr = \Pdo\Mysql::ATTR_INIT_COMMAND;
+            } else {
+                $initCommandAttr = \PDO::MYSQL_ATTR_INIT_COMMAND;
+            }
+
             $options = [
                 \PDO::ATTR_TIMEOUT => $timeout,
                 \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-                \PDO::MYSQL_ATTR_INIT_COMMAND => "SET SESSION sql_mode=''"
+                $initCommandAttr => "SET SESSION sql_mode=''"
             ];
 
             $dsn    = 'mysql:host=127.0.0.1;port=' . $this->port;

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1571,7 +1571,12 @@ class Util
         if (curl_errno($ch)) {
             Util::logError('CURL Error: ' . curl_error($ch));
         }
-        curl_close($ch);
+
+        // curl_close() is deprecated in PHP 8.5+ as it has no effect since PHP 8.0
+        // The resource is automatically closed when it goes out of scope
+        if (PHP_VERSION_ID < 80500) {
+            curl_close($ch);
+        }
 
         return trim($data);
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated memcache functions with fsockopen for PHP 8.4+ compatibility

- Handle PDO MySQL constant deprecation in PHP 8.5+

- Skip curl_close() call in PHP 8.5+ where it's deprecated

- Reorder PowerShell entry alphabetically in modules list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PHP 8.4+ Compatibility Issues"] --> B["Memcached Port Check"]
  A --> C["MySQL PDO Constants"]
  A --> D["cURL Resource Cleanup"]
  B --> B1["Replace memcache_connect with fsockopen"]
  C --> C1["Use Pdo\Mysql::ATTR_INIT_COMMAND for PHP 8.5+"]
  D --> D1["Conditionally call curl_close based on PHP version"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.action.quickPick.php</strong><dd><code>Reorder PowerShell in modules array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/actions/class.action.quickPick.php

<ul><li>Moved PowerShell entry from position after Composer to position after <br>PostgreSQL<br> <li> Maintains alphabetical ordering of module entries</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/174/files#diff-d1f6e26b10d84a231fa30e52206aab0eb80b30eb4a24c22c2fabefb20384ba61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.bin.memcached.php</strong><dd><code>Replace memcache_connect with fsockopen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/bins/class.bin.memcached.php

<ul><li>Replaced deprecated memcache_connect() with fsockopen() to avoid file <br>descriptor leaks in PHP 8.4+<br> <li> Implements memcached protocol verification by sending "version" <br>command and parsing response<br> <li> Improved error handling with separate logic for port open/closed and <br>memcached response validation<br> <li> Simplified conditional logic by removing nested if-else structure</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/174/files#diff-1a911e09bb34608d8185eed250323bcbe2149ca46e646a162bcc4243605fb296">+28/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.bin.mysql.php</strong><dd><code>Handle PDO MySQL constant deprecation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/bins/class.bin.mysql.php

<ul><li>Added PHP version check to use new Pdo\Mysql::ATTR_INIT_COMMAND <br>constant in PHP 8.5+<br> <li> Falls back to PDO::MYSQL_ATTR_INIT_COMMAND for PHP versions below 8.5<br> <li> Applied fix in two locations: checkPort() and checkRootPassword() <br>methods<br> <li> Prevents deprecation warnings when using PDO MySQL attributes</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/174/files#diff-bb9b520dc1ba7fcdc97052f222350e0954f332105a15b043f0250373bcb990b1">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.util.php</strong><dd><code>Conditionally call curl_close for PHP 8.5+</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.util.php

<ul><li>Added PHP version check before calling curl_close() in getApiJson() <br>method<br> <li> Skips curl_close() for PHP 8.5+ where it's deprecated and has no <br>effect<br> <li> Added explanatory comment about automatic resource cleanup in PHP 8.0+</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/174/files#diff-4cf3daa5765ea02c1921901194cf0cfb0786be4ce5b34673e7b6701e0bf37b46">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

