### PR TITLE
Add MariaDB data directory initialization functionality

### DIFF
--- a/core/classes/class.batch.php
+++ b/core/classes/class.batch.php
@@ -232,6 +232,20 @@ class Batch
     }
 
     /**
+     * Initializes MariaDB using a specified path.
+     *
+     * @param string $path The path to the MariaDB initialization script.
+     */
+    public static function initializeMariadb($path)
+    {
+        if (!file_exists($path . '/init.bat')) {
+            Util::logWarning($path . '/init.bat does not exist');
+            return;
+        }
+        self::exec('initializeMariadb', 'CMD /C "' . $path . '/init.bat"', 60);
+    }
+
+    /**
      * Creates a symbolic link.
      *
      * @param string $src The source path.
@@ -257,11 +271,11 @@ class Batch
             self::writeLog('-> removeSymlink: Link does not exist: ' . $link);
             return true; // If the link doesn't exist, nothing to do
         }
-        
+
         // Check if it's a directory symlink
         $isDirectory = is_dir($link);
         $formattedLink = Util::formatWindowsPath($link);
-        
+
         try {
             // Use different commands based on whether it's a directory or file symlink
             if ($isDirectory) {
@@ -271,13 +285,13 @@ class Batch
                 // For file symlinks
                 self::exec('removeSymlink', 'del /F /Q "' . $formattedLink . '"', true, false);
             }
-            
+
             // Check if removal was successful
             if (file_exists($link)) {
                 self::writeLog('-> removeSymlink: Failed to remove symlink: ' . $link);
                 return false;
             }
-            
+
             self::writeLog('-> removeSymlink: Successfully removed symlink: ' . $link);
             return true;
         } catch (Exception $e) {

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1653,6 +1653,11 @@ class Util
     public static function installService($bin, $port, $syntaxCheckCmd, $showWindow = false)
     {
         global $bearsamppLang, $bearsamppWinbinder;
+
+        if (method_exists($bin, 'initData')) {
+            $bin->initData();
+        }
+
         $name     = $bin->getName();
         $service  = $bin->getService();
         $boxTitle = sprintf($bearsamppLang->getValue(Lang::INSTALL_SERVICE_TITLE), $name);
@@ -1765,6 +1770,11 @@ class Util
     public static function startService($bin, $syntaxCheckCmd, $showWindow = false)
     {
         global $bearsamppLang, $bearsamppWinbinder;
+
+        if (method_exists($bin, 'initData')) {
+            $bin->initData();
+        }
+
         $name     = $bin->getName();
         $service  = $bin->getService();
         $boxTitle = sprintf($bearsamppLang->getValue(Lang::START_SERVICE_TITLE), $name);

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1713,7 +1713,7 @@ class Util
 
             return true;
         } else {
-            self::logError(sprintf('Port %s is used by an other application : %s', $name));
+            self::logError(sprintf('Port %s is used by an other application : %s', $port, $isPortInUse));
             if ($showWindow) {
                 $bearsamppWinbinder->messageBoxError(
                     sprintf($bearsamppLang->getValue(Lang::PORT_NOT_USED_BY), $port, $isPortInUse),

--- a/core/classes/class.win32service.php
+++ b/core/classes/class.win32service.php
@@ -520,6 +520,9 @@ class Win32Service
         if ( $this->getName() == BinMysql::SERVICE_NAME ) {
             $bearsamppBins->getMysql()->initData();
         }
+        elseif ( $this->getName() == BinMariadb::SERVICE_NAME ) {
+            $bearsamppBins->getMariadb()->initData();
+        }
         elseif ( $this->getName() == BinMailpit::SERVICE_NAME ) {
             $bearsamppBins->getMailpit()->rebuildConf();
         }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add MariaDB data directory initialization with `initData()` method

- Support both init.bat and mariadb-install-db.exe initialization paths

- Add `getDataDir()` method to retrieve MariaDB data directory path

- Integrate data initialization into service installation and startup flows

- Fix port error logging to include actual port and application name

- Clean up code formatting and whitespace inconsistencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Install/Start"] --> B["Check initData Method"]
  B --> C["MariaDB initData"]
  C --> D["Check init.bat"]
  D -->|Exists| E["Execute init.bat"]
  D -->|Not Found| F["Use mariadb-install-db.exe"]
  E --> G["Verify mysql Directory"]
  F --> G
  G -->|Success| H["Return True"]
  G -->|Failure| I["Return False"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.bin.mariadb.php</strong><dd><code>MariaDB data initialization and getter methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/bins/class.bin.mariadb.php

<ul><li>Add <code>getDataDir()</code> method returning MariaDB data directory path<br> <li> Add comprehensive <code>initData()</code> method with dual initialization <br>strategies<br> <li> Support both init.bat and mariadb-install-db.exe for data <br>initialization<br> <li> Include verification checks and detailed logging throughout <br>initialization process<br> <li> Fix code formatting in <code>getCliExe()</code> and <code>getAdmin()</code> method braces</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/181/files#diff-2f88ec5696e585d98f6b7da5322bbcb9ff7942d2f01576cc04131e4e19019aef">+93/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.batch.php</strong><dd><code>Add MariaDB batch initialization method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.batch.php

<ul><li>Add <code>initializeMariadb()</code> static method for MariaDB initialization via <br>init.bat<br> <li> Method follows same pattern as existing <code>initializePostgresql()</code> with <br>60-second timeout<br> <li> Fix trailing whitespace in <code>removeSymlink()</code> method for code consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/181/files#diff-6526f422f9e17766a239fcab48a107fb925c36da1e882158e7d311c1a1c66d7d">+18/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.win32service.php</strong><dd><code>Add MariaDB initialization to service start</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.win32service.php

<ul><li>Add MariaDB data initialization in <code>start()</code> method alongside MySQL<br> <li> Call <code>initData()</code> when starting MariaDB service<br> <li> Maintain consistency with existing MySQL initialization pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/181/files#diff-c049a530f4820f9af791d858ba41c1aa79ab585638ffdb3cfd25a1c7db420150">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.util.php</strong><dd><code>Integrate data initialization into service operations</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.util.php

<ul><li>Add <code>initData()</code> call in <code>installService()</code> before service installation<br> <li> Add <code>initData()</code> call in <code>startService()</code> before service startup<br> <li> Fix port error logging to use correct variables <code>$port</code> and <code>$isPortInUse</code><br> <li> Ensure data directory is initialized before service operations</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/181/files#diff-4cf3daa5765ea02c1921901194cf0cfb0786be4ce5b34673e7b6701e0bf37b46">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

