### PR TITLE
code-refactor-suggestings

### DIFF
--- a/core/classes/actions/class.action.debugBase.php
+++ b/core/classes/actions/class.action.debugBase.php
@@ -13,6 +13,8 @@
  * Base class for debugging actions across different services (MySQL, MariaDB, Apache, PostgreSQL).
  * This class provides common functionality for executing debug commands and displaying their output.
  * Child classes need to implement service-specific methods to define their behavior.
+ *
+ * @since 2026.2.16
  */
 abstract class ActionDebugBase
 {
@@ -20,6 +22,7 @@ abstract class ActionDebugBase
      * Get the service name for language strings (e.g., 'MYSQL', 'APACHE', 'MARIADB', 'POSTGRESQL')
      *
      * @return string The language constant name for the service
+     * @since 2026.2.16
      */
     abstract protected function getServiceLangConstant();
 
@@ -28,6 +31,7 @@ abstract class ActionDebugBase
      *
      * @param object $bearsamppBins The bins object containing all service binaries
      * @return object The specific binary instance (e.g., BinMysql, BinApache)
+     * @since 2026.2.16
      */
     abstract protected function getBinInstance($bearsamppBins);
 
@@ -38,6 +42,7 @@ abstract class ActionDebugBase
      * - 'editor': boolean indicating if output should be shown in editor (default: false)
      *
      * @return array Command mapping configuration
+     * @since 2026.2.16
      */
     abstract protected function getCommandMapping();
 
@@ -46,6 +51,7 @@ abstract class ActionDebugBase
      * or if it's a direct string (for services like PostgreSQL)
      *
      * @return bool True if output is an array with 'content' key, false if direct string
+     * @since 2026.2.16
      */
     protected function hasContentKey()
     {
@@ -63,6 +69,8 @@ abstract class ActionDebugBase
      * 3. Executes the command and retrieves output
      * 4. Handles syntax check results if applicable
      * 5. Displays output in editor or message box
+     *
+     * @since 2026.2.16
      */
     public function __construct($args)
     {
@@ -88,7 +96,6 @@ abstract class ActionDebugBase
                     $editor = true;
                 }
             }
-
             $caption .= ' (' . $command . ')';
 
             // Execute the command and get output
@@ -124,6 +131,7 @@ abstract class ActionDebugBase
      *
      * @param string $command The command to check
      * @return bool True if it's a syntax check command
+     * @since 2026.2.16
      */
     protected function isSyntaxCheckCommand($command)
     {


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Add @since annotations to class and all public/protected methods

- Document version 2026.2.16 for ActionDebugBase and its methods

- Remove unnecessary blank line in constructor for code cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ActionDebugBase class"] -->|Add @since 2026.2.16| B["Class documentation"]
  A -->|Add @since annotations| C["Method documentation"]
  C -->|getServiceLangConstant| D["Abstract methods"]
  C -->|getBinInstance| D
  C -->|getCommandMapping| D
  C -->|hasContentKey| E["Protected methods"]
  C -->|isSyntaxCheckCommand| E
  C -->|__construct| F["Public methods"]
  A -->|Remove blank line| G["Code formatting"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.action.debugBase.php</strong><dd><code>Add @since annotations and minor formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/actions/class.action.debugBase.php

<ul><li>Add @since 2026.2.16 annotation to class-level documentation<br> <li> Add @since 2026.2.16 annotations to all abstract and protected methods <br>(getServiceLangConstant, getBinInstance, getCommandMapping, <br>hasContentKey, isSyntaxCheckCommand)<br> <li> Add @since 2026.2.16 annotation to public constructor method<br> <li> Remove unnecessary blank line before caption assignment in constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/184/files#diff-e2190d54cd0df8031d5b96c769d2413c247f51650614faf1b5603d550e9ee988">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

