### PR TITLE
Refactor codebase for maintainability and efficiency improvements

### DIFF
--- a/core/classes/actions/class.action.changePort.php
+++ b/core/classes/actions/class.action.changePort.php
@@ -39,43 +39,18 @@ class ActionChangePort
         global $bearsamppLang, $bearsamppBins, $bearsamppWinbinder;
 
         if ( isset( $args[0] ) && !empty( $args[0] ) ) {
-            $this->bin               = $bearsamppBins->getApache();
-            $this->currentPort       = $bearsamppBins->getApache()->getPort();
+            $bin = $bearsamppBins->getBinByName($args[0]);
+            if ($bin !== null) {
+                $this->bin = $bin;
+                // Mailpit exposes an SMTP port separately; all other services use getPort()
+                $this->currentPort = ($args[0] == $bearsamppBins->getMailpit()->getName())
+                    ? $bin->getSmtpPort()
+                    : $bin->getPort();
+            } else {
+                $this->bin         = $bearsamppBins->getApache();
+                $this->currentPort = $bearsamppBins->getApache()->getPort();
+            }
             $this->cntProcessActions = 3;
-            if ( $args[0] == $bearsamppBins->getMysql()->getName() ) {
-                $this->bin               = $bearsamppBins->getMysql();
-                $this->currentPort       = $bearsamppBins->getMysql()->getPort();
-                $this->cntProcessActions = 3;
-            }
-            elseif ( $args[0] == $bearsamppBins->getMariadb()->getName() ) {
-                $this->bin               = $bearsamppBins->getMariadb();
-                $this->currentPort       = $bearsamppBins->getMariadb()->getPort();
-                $this->cntProcessActions = 3;
-            }
-            elseif ( $args[0] == $bearsamppBins->getPostgresql()->getName() ) {
-                $this->bin               = $bearsamppBins->getPostgresql();
-                $this->currentPort       = $bearsamppBins->getPostgresql()->getPort();
-                $this->cntProcessActions = 3;
-            }
-            elseif ( $args[0] == $bearsamppBins->getMailpit()->getName() ) {
-                $this->bin               = $bearsamppBins->getMailpit();
-                $this->currentPort       = $bearsamppBins->getMailpit()->getSmtpPort();
-                $this->cntProcessActions = 3;
-            }
-            elseif ( $args[0] == $bearsamppBins->getMemcached()->getName() ) {
-                $this->bin               = $bearsamppBins->getMemcached();
-                $this->currentPort       = $bearsamppBins->getMemcached()->getPort();
-                $this->cntProcessActions = 3;
-            } elseif ($args[0] == $bearsamppBins->getXlight()->getName()) {
-                $this->bin               = $bearsamppBins->getXlight();
-                $this->currentPort       = $bearsamppBins->getXlight()->getPort();
-                $this->cntProcessActions = 3;
-            }
-            elseif ( $args[0] == $bearsamppBins->getXlight()->getName() ) {
-                $this->bin               = $bearsamppBins->getXlight();
-                $this->currentPort       = $bearsamppBins->getXlight()->getPort();
-                $this->cntProcessActions = 3;
-            }
 
             $bearsamppWinbinder->reset();
             $this->wbWindow = $bearsamppWinbinder->createAppWindow( sprintf( $bearsamppLang->getValue( Lang::CHANGE_PORT_TITLE ), $args[0] ), 380, 170, WBC_NOTIFY, WBC_KEYDOWN | WBC_KEYUP );

--- a/core/classes/actions/class.action.checkPort.php
+++ b/core/classes/actions/class.action.checkPort.php
@@ -34,27 +34,14 @@ class ActionCheckPort
             // Determine if SSL is to be used
             $ssl = isset( $args[2] ) && !empty( $args[2] );
 
-            // Check the port for the specified service
-            if ( $args[0] == $bearsamppBins->getApache()->getName() ) {
-                $bearsamppBins->getApache()->checkPort( $args[1], $ssl, true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMysql()->getName() ) {
-                $bearsamppBins->getMysql()->checkPort( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMariadb()->getName() ) {
-                $bearsamppBins->getMariadb()->checkPort( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getPostgresql()->getName() ) {
-                $bearsamppBins->getPostgresql()->checkPort( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMailpit()->getName() ) {
-                $bearsamppBins->getMailpit()->checkPort( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMemcached()->getName() ) {
-                $bearsamppBins->getMemcached()->checkPort( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getXlight()->getName() ) {
-                $bearsamppBins->getXlight()->checkPort( $args[1], true );
+            $bin = $bearsamppBins->getBinByName($args[0]);
+            if ($bin !== null) {
+                // Apache accepts an extra $ssl parameter; all other bins do not
+                if ($args[0] == $bearsamppBins->getApache()->getName()) {
+                    $bin->checkPort($args[1], $ssl, true);
+                } else {
+                    $bin->checkPort($args[1], true);
+                }
             }
         }
     }

--- a/core/classes/actions/class.action.enable.php
+++ b/core/classes/actions/class.action.enable.php
@@ -27,32 +27,9 @@ class ActionEnable
 
         if ( isset( $args[0] ) && !empty( $args[0] ) && isset( $args[1] ) ) {
             Util::startLoading();
-            if ( $args[0] == $bearsamppBins->getApache()->getName() ) {
-                $bearsamppBins->getApache()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getPhp()->getName() ) {
-                $bearsamppBins->getPhp()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMysql()->getName() ) {
-                $bearsamppBins->getMysql()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMariadb()->getName() ) {
-                $bearsamppBins->getMariadb()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getNodejs()->getName() ) {
-                $bearsamppBins->getNodejs()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getPostgresql()->getName() ) {
-                $bearsamppBins->getPostgresql()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMailpit()->getName() ) {
-                $bearsamppBins->getMailpit()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getMemcached()->getName() ) {
-                $bearsamppBins->getMemcached()->setEnable( $args[1], true );
-            }
-            elseif ( $args[0] == $bearsamppBins->getXlight()->getName() ) {
-                $bearsamppBins->getXlight()->setEnable( $args[1], true );
+            $bin = $bearsamppBins->getBinByName($args[0]);
+            if ($bin !== null) {
+                $bin->setEnable($args[1], true);
             }
         }
     }

--- a/core/classes/actions/class.action.loading.php
+++ b/core/classes/actions/class.action.loading.php
@@ -272,7 +272,7 @@ class ActionLoading
                     'exit(0);" > nul 2>&1';
                 
                 // Execute the command in background
-                pclose(popen('start /B ' . $checkCmd, 'r'));
+                CommandRunner::background($checkCmd);
                 
                 // Wait for the result with timeout
                 $startWait = microtime(true);

--- a/core/classes/actions/class.action.switchVersion.php
+++ b/core/classes/actions/class.action.switchVersion.php
@@ -239,34 +239,19 @@ class ActionSwitchVersion
         $this->bearsamppSplash->incrProgressBar();
         $bearsamppBins->reload();
 
-        // After reloading bins, get a fresh service reference from the reloaded bin
-        // This ensures we're using the updated service instance with new configuration
+        // After reloading bins, get a fresh service reference from the reloaded bin.
+        // This ensures we're using the updated service instance with new configuration.
         if ($this->service != null) {
-            // Get the reloaded bin and its fresh service instance
-            if ($this->bin->getName() == $bearsamppBins->getApache()->getName()) {
-                $this->service = $bearsamppBins->getApache()->getService();
-                Util::logTrace("Refreshed service reference from reloaded Apache bin");
-            } elseif ($this->bin->getName() == $bearsamppBins->getPhp()->getName()) {
+            // PHP is a special case: it runs under Apache's service, not its own.
+            if ($this->bin->getName() == $bearsamppBins->getPhp()->getName()) {
                 $this->service = $bearsamppBins->getApache()->getService();
                 Util::logTrace("Refreshed service reference from reloaded Apache bin (for PHP)");
-            } elseif ($this->bin->getName() == $bearsamppBins->getMysql()->getName()) {
-                $this->service = $bearsamppBins->getMysql()->getService();
-                Util::logTrace("Refreshed service reference from reloaded MySQL bin");
-            } elseif ($this->bin->getName() == $bearsamppBins->getMariadb()->getName()) {
-                $this->service = $bearsamppBins->getMariadb()->getService();
-                Util::logTrace("Refreshed service reference from reloaded MariaDB bin");
-            } elseif ($this->bin->getName() == $bearsamppBins->getPostgresql()->getName()) {
-                $this->service = $bearsamppBins->getPostgresql()->getService();
-                Util::logTrace("Refreshed service reference from reloaded PostgreSQL bin");
-            } elseif ($this->bin->getName() == $bearsamppBins->getMemcached()->getName()) {
-                $this->service = $bearsamppBins->getMemcached()->getService();
-                Util::logTrace("Refreshed service reference from reloaded Memcached bin");
-            } elseif ($this->bin->getName() == $bearsamppBins->getMailpit()->getName()) {
-                $this->service = $bearsamppBins->getMailpit()->getService();
-                Util::logTrace("Refreshed service reference from reloaded Mailpit bin");
-            } elseif ($this->bin->getName() == $bearsamppBins->getXlight()->getName()) {
-                $this->service = $bearsamppBins->getXlight()->getService();
-                Util::logTrace("Refreshed service reference from reloaded Xlight bin");
+            } else {
+                $freshBin = $bearsamppBins->getBinByName($this->bin->getName());
+                if ($freshBin !== null) {
+                    $this->service = $freshBin->getService();
+                    Util::logTrace("Refreshed service reference from reloaded " . $this->bin->getName() . " bin");
+                }
             }
         }
 

--- a/core/classes/bins/class.bins.php
+++ b/core/classes/bins/class.bins.php
@@ -207,6 +207,26 @@ class Bins
     }
 
     /**
+     * Finds a bin by its display name.
+     *
+     * Iterates over all bins and returns the one whose getName() matches the
+     * provided string. Returns null if no bin matches, so callers can handle
+     * unrecognised names without branching on each individual service.
+     *
+     * @param string $name The display name to look up (as returned by getName()).
+     * @return object|null The matching bin object, or null if not found.
+     */
+    public function getBinByName(string $name): ?object
+    {
+        foreach ($this->getAll() as $bin) {
+            if ($bin->getName() === $name) {
+                return $bin;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Retrieves the services for all enabled bin modules.
      *
      * @return array An associative array of service names and their corresponding service objects.

--- a/core/classes/class.commandrunner.php
+++ b/core/classes/class.commandrunner.php
@@ -1,0 +1,190 @@
+<?php
+/*
+ * Copyright (c) 2021-2024 Bearsampp
+ * License:  GNU General Public License version 3 or later; see LICENSE.txt
+ * Author: Bear
+ * Website: https://bearsampp.com
+ * Github: https://github.com/Bearsampp
+ */
+
+/**
+ * Class CommandRunner
+ *
+ * Centralizes all PHP shell-execution primitives (proc_open, popen, shell_exec)
+ * so that every external command goes through a single, auditable point with
+ * consistent argument escaping and logging.
+ *
+ * Three execution modes:
+ *  - exec()      capture stdout/stderr, hidden console window  (replaces proc_open)
+ *  - stream()    stream output line-by-line via callback       (replaces popen)
+ *  - shellExec() capture output from a fully-formed command    (replaces shell_exec)
+ *
+ * Rules:
+ *  - exec() and stream() always escapeshellarg() every argument individually.
+ *  - shellExec() is reserved for hardcoded commands with no dynamic user input.
+ *    Pass dynamic arguments through exec() or stream() instead.
+ */
+class CommandRunner
+{
+    /**
+     * Writes a log entry to the batch log file.
+     *
+     * @param string $log The message to log.
+     */
+    private static function writeLog(string $log): void
+    {
+        global $bearsamppRoot;
+        Util::logDebug($log, $bearsamppRoot->getBatchLogFilePath());
+    }
+
+    /**
+     * Execute an executable with arguments, capturing stdout and stderr.
+     *
+     * Each argument is individually escaped with escapeshellarg(). The console
+     * window is hidden on Windows via bypass_shell + CREATE_NO_WINDOW semantics.
+     *
+     * @param string $executable Path to the executable (will be escapeshellarg'd).
+     * @param array  $args       Arguments, each will be escapeshellarg'd.
+     * @param string $stderr     Populated with any stderr output on return.
+     * @return string|false stdout output on success, false if the process could not start.
+     */
+    public static function exec(string $executable, array $args = [], string &$stderr = ''): string|false
+    {
+        $cmd = escapeshellarg($executable);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg((string) $arg);
+        }
+
+        self::writeLog('CommandRunner::exec: ' . $cmd);
+
+        $descriptorspec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = @proc_open($cmd, $descriptorspec, $pipes, null, null, ['bypass_shell' => true]);
+
+        if (!is_resource($process)) {
+            self::writeLog('CommandRunner::exec: failed to start process: ' . $cmd);
+            return false;
+        }
+
+        fclose($pipes[0]);
+        $output = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        if (!empty($stderr)) {
+            self::writeLog('CommandRunner::exec stderr: ' . $stderr);
+        }
+
+        return $output;
+    }
+
+    /**
+     * Execute an executable with arguments, combining stdout and stderr.
+     *
+     * Convenience wrapper around exec() for callers that need both streams merged
+     * (e.g. sc.exe which may send status messages to either stream).
+     *
+     * @param string $executable Path to the executable (will be escapeshellarg'd).
+     * @param array  $args       Arguments, each will be escapeshellarg'd.
+     * @return string|false Combined output, or false if the process could not start.
+     */
+    public static function execCombined(string $executable, array $args = []): string|false
+    {
+        $stderr = '';
+        $output = self::exec($executable, $args, $stderr);
+
+        if ($output === false) {
+            return false;
+        }
+
+        if (!empty($stderr)) {
+            $output .= "\n" . $stderr;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Execute an executable with arguments, streaming output line-by-line.
+     *
+     * Useful for long-running processes that emit progress information.
+     * Each argument is individually escaped with escapeshellarg(). Lines are
+     * split on carriage-return (\r) to match Windows progress-reporting conventions.
+     * Any data remaining in the buffer after EOF is flushed as a final line.
+     *
+     * @param string   $executable   Path to the executable (will be escapeshellarg'd).
+     * @param array    $args         Arguments, each will be escapeshellarg'd.
+     * @param callable $lineCallback Invoked with each trimmed output line as a string.
+     * @return int|false Process exit code on success, false if the process could not start.
+     */
+    public static function stream(string $executable, array $args, callable $lineCallback): int|false
+    {
+        $cmd = escapeshellarg($executable);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg((string) $arg);
+        }
+
+        self::writeLog('CommandRunner::stream: ' . $cmd);
+
+        $process = popen($cmd, 'rb');
+        if (!$process) {
+            self::writeLog('CommandRunner::stream: failed to start process: ' . $cmd);
+            return false;
+        }
+
+        $buffer = '';
+        while (!feof($process)) {
+            $buffer .= fread($process, 8192);
+            while (($pos = strpos($buffer, "\r")) !== false) {
+                $line   = trim(substr($buffer, 0, $pos));
+                $buffer = substr($buffer, $pos + 1);
+                $lineCallback($line);
+            }
+        }
+
+        // Flush any remaining data not terminated by \r
+        if (!empty($buffer)) {
+            $lineCallback(trim($buffer));
+        }
+
+        return pclose($process);
+    }
+
+    /**
+     * Launch a command in the background without waiting for output.
+     *
+     * Uses the Windows "start /B" cmd.exe idiom to detach the process immediately.
+     * The caller is responsible for ensuring $command is properly constructed;
+     * use escapeshellarg() on any dynamic values before passing them in.
+     *
+     * @param string $command Fully-formed command string to run in the background.
+     */
+    public static function background(string $command): void
+    {
+        self::writeLog('CommandRunner::background: ' . $command);
+        pclose(popen('start /B ' . $command, 'r'));
+    }
+
+    /**
+     * Execute a fully-formed shell command and return its output.
+     *
+     * Only use this for commands that contain no dynamic user input (e.g. hardcoded
+     * system queries such as "net session" or "whoami /groups"). For commands with
+     * dynamic arguments, use exec() or stream() instead so that escaping is enforced
+     * at the boundary.
+     *
+     * @param string $command Fully-formed command string. Must not contain unescaped user input.
+     * @return string|null Command output, or null if the command could not be run.
+     */
+    public static function shellExec(string $command): ?string
+    {
+        self::writeLog('CommandRunner::shellExec: ' . $command);
+        return shell_exec($command);
+    }
+}

--- a/core/classes/class.core.php
+++ b/core/classes/class.core.php
@@ -501,104 +501,53 @@ class Core
             return false;
         }
 
-        // Command to test the archive and get the number of files
-        $testCommand = escapeshellarg( $sevenZipPath ) . ' t ' . escapeshellarg( $filePath ) . ' -y -bsp1';
-        $testOutput  = shell_exec( $testCommand );
+        // Test the archive to determine the number of files
+        $testOutput = CommandRunner::exec($sevenZipPath, ['t', $filePath, '-y', '-bsp1']);
+        preg_match('/Files: (\d+)/', $testOutput !== false ? $testOutput : '', $matches);
+        $numFiles = isset($matches[1]) ? (int) $matches[1] : 0;
+        Util::logTrace('Number of files to be extracted: ' . $numFiles);
 
-        // Extract the number of files from the test command output
-        preg_match( '/Files: (\d+)/', $testOutput, $matches );
-        $numFiles = isset( $matches[1] ) ? (int) $matches[1] : 0;
-        Util::logTrace( 'Number of files to be extracted: ' . $numFiles );
-
-        // Command to extract the archive
-        $command = escapeshellarg( $sevenZipPath ) . ' x ' . escapeshellarg( $filePath ) . ' -y -bsp1 -bb0 -o' . escapeshellarg( $destination );
-        Util::logTrace( 'Executing command: ' . $command );
-
-        $process = popen( $command, 'rb' );
-
-        if ( $process ) {
-            $buffer = '';
-            while ( !feof( $process ) ) {
-                $buffer .= fread( $process, 8192 ); // Read in chunks of 8KB
-                while ( ($pos = strpos( $buffer, "\r" )) !== false ) {
-                    $line   = substr( $buffer, 0, $pos );
-                    $buffer = substr( $buffer, $pos + 1 );
-                    $line   = trim( $line ); // Remove any leading/trailing whitespace
-                    Util::logTrace( "Processing line: $line" );
-
-                    // Check if the line indicates everything is okay
-                    if ( $line === "Everything is Ok" ) {
-                        if ( $progressCallback ) {
-                            Util::logTrace( "Extraction progress: 100%" );
-                            call_user_func( $progressCallback, 100 );
-                            Util::logTrace( "Progress callback called with percentage: 100" );
-                        }
+        // Extract the archive, streaming progress line-by-line
+        $returnVar = CommandRunner::stream(
+            $sevenZipPath,
+            ['x', $filePath, '-y', '-bsp1', '-bb0', '-o' . $destination],
+            function (string $line) use ($progressCallback) {
+                Util::logTrace("Processing line: $line");
+                if ($line === 'Everything is Ok') {
+                    if ($progressCallback) {
+                        Util::logTrace('Extraction progress: 100%');
+                        call_user_func($progressCallback, 100);
                     }
-                    else if ( $progressCallback && preg_match( '/(?:^|\s)(\d+)%/', $line, $matches ) ) {
-                        $currentPercentage = intval( $matches[1] );
-                        Util::logTrace( "Extraction progress: $currentPercentage%" );
-                        call_user_func( $progressCallback, $currentPercentage );
-                        Util::logTrace( "Progress callback called with percentage: $currentPercentage" );
-                    }
-                    else {
-                        Util::logTrace( "Line did not match pattern: $line" );
-                    }
+                } elseif ($progressCallback && preg_match('/(?:^|\s)(\d+)%/', $line, $matches)) {
+                    $currentPercentage = intval($matches[1]);
+                    Util::logTrace("Extraction progress: $currentPercentage%");
+                    call_user_func($progressCallback, $currentPercentage);
+                } else {
+                    Util::logTrace("Line did not match pattern: $line");
                 }
             }
+        );
 
-            // Process any remaining data in the buffer
-            if ( !empty( $buffer ) ) {
-                $line = trim( $buffer );
-                Util::logTrace( "Processing remaining line: $line" );
-
-                // Check if the remaining line indicates everything is okay
-                if ( $line === "Everything is Ok" ) {
-                    if ( $progressCallback ) {
-                        Util::logTrace( "Extraction progress: 100%" );
-                        call_user_func( $progressCallback, 100 );
-                        Util::logTrace( "Progress callback called with percentage: 100" );
-                    }
-                }
-                else if ( $progressCallback && preg_match( '/(?:^|\s)(\d+)%/', $line, $matches ) ) {
-                    $currentPercentage = intval( $matches[1] );
-                    Util::logTrace( "Extraction progress: $currentPercentage%" );
-                    call_user_func( $progressCallback, $currentPercentage );
-                    Util::logTrace( "Progress callback called with percentage: $currentPercentage" );
-                }
-                else {
-                    Util::logTrace( "Remaining line did not match pattern: $line" );
-                }
-            }
-
-            $returnVar = pclose( $process );
-            Util::logTrace( 'Command return value: ' . $returnVar );
-
-            // Set progress to 100% if the command was successful
-            if ( $returnVar === 0 && $progressCallback ) {
-                Util::logTrace( "Extraction completed successfully. Setting progress to 100%" );
-                call_user_func( $progressCallback, 100 );
-                Util::logTrace( "Progress callback called with percentage: 100" );
-
-                // Adding a small delay to ensure the progress bar update is processed
-                usleep( 100000 ); // 100 milliseconds
-            }
-
-            if ( $returnVar === 0 ) {
-                Util::logDebug( 'Successfully unzipped file to: ' . $destination );
-
-                return ['success' => true, 'numFiles' => $numFiles];
-            }
-            else {
-                Util::logError( 'Failed to unzip file. Command return value: ' . $returnVar );
-
-                return ['error' => 'Failed to unzip file', 'numFiles' => $numFiles];
-            }
-        }
-        else {
-            Util::logError( 'Failed to open process for command: ' . $command );
-
+        if ($returnVar === false) {
+            Util::logError('Failed to open process for: ' . $sevenZipPath);
             return ['error' => 'Failed to open process', 'numFiles' => $numFiles];
         }
+
+        Util::logTrace('Command return value: ' . $returnVar);
+
+        if ($returnVar === 0 && $progressCallback) {
+            Util::logTrace('Extraction completed successfully. Setting progress to 100%');
+            call_user_func($progressCallback, 100);
+            usleep(100000); // 100 milliseconds
+        }
+
+        if ($returnVar === 0) {
+            Util::logDebug('Successfully unzipped file to: ' . $destination);
+            return ['success' => true, 'numFiles' => $numFiles];
+        }
+
+        Util::logError('Failed to unzip file. Command return value: ' . $returnVar);
+        return ['error' => 'Failed to unzip file', 'numFiles' => $numFiles];
     }
 
     /**

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -159,7 +159,7 @@ class Util
     {
         if (is_string($name)) {
             if ($type == 'text') {
-                $value = (isset($_GET[$name]) && !empty($_GET[$name])) ? stripslashes($_GET[$name]) : '';
+                $value = (isset($_GET[$name]) && !empty($_GET[$name])) ? $_GET[$name] : '';
                 // Additional sanitization: remove null bytes and control characters
                 return filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
             } elseif ($type == 'numeric') {
@@ -186,7 +186,7 @@ class Util
     {
         if (is_string($name)) {
             if ($type == 'text') {
-                return (isset($_POST[$name]) && !empty($_POST[$name])) ? stripslashes(trim($_POST[$name])) : '';
+                return (isset($_POST[$name]) && !empty($_POST[$name])) ? trim($_POST[$name]) : '';
             } elseif ($type == 'number') {
                 return (isset($_POST[$name]) && is_numeric($_POST[$name])) ? intval($_POST[$name]) : '';
             } elseif ($type == 'float') {

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -641,7 +641,7 @@ class Util
 
         // Method 1: Try using shell_exec with 'net session' command
         // This command only succeeds when run with admin privileges
-        $output = @shell_exec('net session 2>&1');
+        $output = CommandRunner::shellExec('net session 2>&1');
         if ($output !== null) {
             // Check for access denied errors
             if (stripos($output, 'Access is denied') !== false ||
@@ -660,7 +660,7 @@ class Util
         }
 
         // Method 2: Check using whoami command (Windows Vista and later)
-        $output = @shell_exec('whoami /groups 2>&1');
+        $output = CommandRunner::shellExec('whoami /groups 2>&1');
         if ($output !== null && !empty($output)) {
             // Look for the Administrators group or High Mandatory Level
             if (stripos($output, 'S-1-16-12288') !== false || // High Mandatory Level

--- a/core/classes/class.win32native.php
+++ b/core/classes/class.win32native.php
@@ -18,7 +18,8 @@ class Win32Native
     // ========================================================================
     // COM Connection Cache
     // Each COM object is created once per PHP process and reused across calls.
-    // Call resetConnections() if a COM operation fails and you need a fresh object.
+    // On a COM/WMI failure the catching method calls resetConnections() so the
+    // next call gets a fresh object instead of reusing a broken cached instance.
     // ========================================================================
 
     /** @var COM|null Cached WMI connection to root/cimv2 (process/service queries) */
@@ -124,6 +125,7 @@ class Win32Native
             return $result;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('getProcessList: COM exception: ' . $e->getMessage());
             return [];
         }
@@ -189,6 +191,7 @@ class Win32Native
             return true;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('killProcess: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -218,6 +221,7 @@ class Win32Native
             return false;
 
         } catch (Exception $e) {
+            self::resetConnections();
             return false;
         }
     }
@@ -261,6 +265,7 @@ class Win32Native
             return false;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('getProcessInfo: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -311,6 +316,7 @@ class Win32Native
             return $result;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('findProcessesByName: COM exception: ' . $e->getMessage());
             return [];
         }
@@ -429,6 +435,7 @@ class Win32Native
                     }
 
                 } catch (Exception $e) {
+                    self::$wmiStdRegProv = null;
                     Util::logError('registryExists: StdRegProv exception during key check: ' . $e->getMessage());
                     return false;
                 }
@@ -448,6 +455,7 @@ class Win32Native
             }
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('registryExists: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -543,6 +551,7 @@ class Win32Native
             return true;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('registrySetValue: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -586,6 +595,7 @@ class Win32Native
                 return true;
             }
 
+            self::resetConnections();
             Util::logError('registryDeleteValue: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -624,6 +634,7 @@ class Win32Native
                 return true;
             }
 
+            self::resetConnections();
             Util::logError('registryDeleteKey: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -665,6 +676,7 @@ class Win32Native
             }
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('getSpecialFolderPath: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -717,6 +729,7 @@ class Win32Native
             return true;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('createShortcut: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -944,6 +957,7 @@ class Win32Native
             return false;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('getServiceInfo: COM exception: ' . $e->getMessage());
             return false;
         }
@@ -999,6 +1013,7 @@ class Win32Native
             return $result;
 
         } catch (Exception $e) {
+            self::resetConnections();
             Util::logError('listServices: COM exception: ' . $e->getMessage());
             return [];
         }
@@ -1030,6 +1045,7 @@ class Win32Native
             return false;
 
         } catch (Exception $e) {
+            self::resetConnections();
             return false;
         }
     }
@@ -1060,6 +1076,7 @@ class Win32Native
             return false;
 
         } catch (Exception $e) {
+            self::resetConnections();
             return false;
         }
     }

--- a/core/classes/class.win32native.php
+++ b/core/classes/class.win32native.php
@@ -15,6 +15,65 @@
  */
 class Win32Native
 {
+    // ========================================================================
+    // COM Connection Cache
+    // Each COM object is created once per PHP process and reused across calls.
+    // Call resetConnections() if a COM operation fails and you need a fresh object.
+    // ========================================================================
+
+    /** @var COM|null Cached WMI connection to root/cimv2 (process/service queries) */
+    private static ?COM $wmiCimv2 = null;
+
+    /** @var COM|null Cached WMI connection to root/default:StdRegProv (registry key checks) */
+    private static ?COM $wmiStdRegProv = null;
+
+    /** @var COM|null Cached WScript.Shell object (registry values, shortcuts, special folders) */
+    private static ?COM $wscriptShell = null;
+
+    /**
+     * Returns the cached WMI cimv2 connection, creating it on first use.
+     */
+    private static function getWmiCimv2(): COM
+    {
+        if (self::$wmiCimv2 === null) {
+            self::$wmiCimv2 = new COM("winmgmts://./root/cimv2");
+        }
+        return self::$wmiCimv2;
+    }
+
+    /**
+     * Returns the cached WMI StdRegProv connection, creating it on first use.
+     */
+    private static function getWmiStdRegProv(): COM
+    {
+        if (self::$wmiStdRegProv === null) {
+            self::$wmiStdRegProv = new COM("winmgmts://./root/default:StdRegProv");
+        }
+        return self::$wmiStdRegProv;
+    }
+
+    /**
+     * Returns the cached WScript.Shell object, creating it on first use.
+     */
+    private static function getWscriptShell(): COM
+    {
+        if (self::$wscriptShell === null) {
+            self::$wscriptShell = new COM("WScript.Shell");
+        }
+        return self::$wscriptShell;
+    }
+
+    /**
+     * Clears all cached COM connections.
+     * Call this after a COM operation fails so the next call gets a fresh connection.
+     */
+    public static function resetConnections(): void
+    {
+        self::$wmiCimv2      = null;
+        self::$wmiStdRegProv = null;
+        self::$wscriptShell  = null;
+    }
+
     /**
      * Gets a list of running processes using COM/WMI.
      * Replaces VBS WMI process query with direct PHP COM access.
@@ -30,7 +89,7 @@ class Win32Native
 
         try {
             // Create WMI connection
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
 
             // Build WQL query
             if (empty($properties)) {
@@ -91,7 +150,7 @@ class Win32Native
 
         try {
             // Create WMI connection
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
 
             // Query for specific process
             $query = "SELECT * FROM Win32_Process WHERE ProcessID = {$pid}";
@@ -148,7 +207,7 @@ class Win32Native
         }
 
         try {
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
             $query = "SELECT ProcessID FROM Win32_Process WHERE ProcessID = {$pid}";
             $processes = $wmi->ExecQuery($query);
 
@@ -181,7 +240,7 @@ class Win32Native
         }
 
         try {
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
             $selectClause = implode(', ', $properties);
             $query = "SELECT {$selectClause} FROM Win32_Process WHERE ProcessID = {$pid}";
             $processes = $wmi->ExecQuery($query);
@@ -225,7 +284,7 @@ class Win32Native
         }
 
         try {
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
             $selectClause = implode(', ', $properties);
 
             // Sanitize the name parameter to prevent WQL injection
@@ -318,7 +377,7 @@ class Win32Native
                 // Use StdRegProv::EnumKey for reliable key existence checking
                 // This avoids false negatives from checking for a default value that may not exist
                 try {
-                    $wmi = new COM("winmgmts://./root/default:StdRegProv");
+                    $wmi = self::getWmiStdRegProv();
 
                     // Map hive names to WMI constants
                     $hiveConstMap = [
@@ -377,7 +436,7 @@ class Win32Native
                 // Check if a specific value exists within the key
                 // Use WScript.Shell::RegRead for value existence
                 try {
-                    $shell = new COM("WScript.Shell");
+                    $shell = self::getWscriptShell();
                     $valuePath = $regPath . '\\' . $value;
                     $shell->RegRead($valuePath);
                     Util::logDebug('registryExists: Value found');
@@ -420,7 +479,7 @@ class Win32Native
         $startTime = microtime(true);
 
         try {
-            $shell = new COM("WScript.Shell");
+            $shell = self::getWscriptShell();
             $result = $shell->RegRead($regPath);
 
             $duration = round((microtime(true) - $startTime) * 1000, 2);
@@ -468,7 +527,7 @@ class Win32Native
         $startTime = microtime(true);
 
         try {
-            $shell = new COM("WScript.Shell");
+            $shell = self::getWscriptShell();
 
             // Convert data based on type
             if ($type === 'REG_DWORD') {
@@ -508,7 +567,7 @@ class Win32Native
         $startTime = microtime(true);
 
         try {
-            $shell = new COM("WScript.Shell");
+            $shell = self::getWscriptShell();
 
             // Delete the value
             $shell->RegDelete($regPath);
@@ -548,7 +607,7 @@ class Win32Native
         Util::logDebug('registryDeleteKey: Deleting ' . $regPath . ' (COM)');
 
         try {
-            $shell = new COM("WScript.Shell");
+            $shell = self::getWscriptShell();
 
             // Delete the key (note the trailing backslash)
             $shell->RegDelete($regPath);
@@ -588,7 +647,7 @@ class Win32Native
         $startTime = microtime(true);
 
         try {
-            $shell = new COM("WScript.Shell");
+            $shell = self::getWscriptShell();
 
             // Get the special folder path
             $path = $shell->SpecialFolders($folderName);
@@ -629,7 +688,7 @@ class Win32Native
         $startTime = microtime(true);
 
         try {
-            $shell = new COM("WScript.Shell");
+            $shell = self::getWscriptShell();
 
             // Create the shortcut object
             $shortcut = $shell->CreateShortcut($shortcutPath);
@@ -836,7 +895,7 @@ class Win32Native
 
         try {
             // Create WMI connection
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
 
             // Default properties if none specified
             if (empty($properties)) {
@@ -905,7 +964,7 @@ class Win32Native
 
         try {
             // Create WMI connection
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
 
             // Default properties if none specified
             if (empty($properties)) {
@@ -955,7 +1014,7 @@ class Win32Native
     public static function serviceExists($serviceName)
     {
         try {
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
             // Sanitize the serviceName parameter to prevent WQL injection
             // Escape single quotes by doubling them (WQL standard)
             $safeServiceName = str_replace("'", "''", $serviceName);
@@ -985,7 +1044,7 @@ class Win32Native
     public static function getServiceState($serviceName)
     {
         try {
-            $wmi = new COM("winmgmts://./root/cimv2");
+            $wmi = self::getWmiCimv2();
             // Sanitize the serviceName parameter to prevent WQL injection
             // Escape single quotes by doubling them (WQL standard)
             $safeServiceName = str_replace("'", "''", $serviceName);

--- a/core/classes/class.win32service.php
+++ b/core/classes/class.win32service.php
@@ -665,53 +665,6 @@ class Win32Service
      *
      * @return array|false Service information array or false if service doesn't exist
      */
-    /**
-     * Execute a command with hidden console window.
-     * Prevents command prompt flash during execution.
-     *
-     * @param string $command The command to execute
-     * @return string|false The command output or false on failure
-     */
-    private function execHidden($command)
-    {
-        // Use proc_open with hidden window flags
-        $descriptorspec = [
-            0 => ['pipe', 'r'],  // stdin
-            1 => ['pipe', 'w'],  // stdout
-            2 => ['pipe', 'w']   // stderr
-        ];
-
-        // On Windows, use CREATE_NO_WINDOW flag to hide console
-        $options = ['bypass_shell' => true];
-
-        $process = @proc_open($command, $descriptorspec, $pipes, null, null, $options);
-
-        if (!is_resource($process)) {
-            return false;
-        }
-
-        // Close stdin
-        fclose($pipes[0]);
-
-        // Read stdout
-        $output = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
-
-        // Read stderr
-        $errors = stream_get_contents($pipes[2]);
-        fclose($pipes[2]);
-
-        // Close process
-        proc_close($process);
-
-        // Combine output and errors for sc.exe
-        if (!empty($errors)) {
-            $output .= "\n" . $errors;
-        }
-
-        return $output;
-    }
-
     public function fastServiceCheck()
     {
         Util::logTrace("Starting fastServiceCheck for service: " . $this->getName());
@@ -720,10 +673,9 @@ class Win32Service
 
         // Use sc.exe to query service - this is very fast and reliable
         // Execute with hidden window to prevent command prompt flash
-        $command = 'sc query "' . $this->getName() . '"';
-        Util::logTrace("Executing command: " . $command);
+        Util::logTrace("Executing: sc query " . $this->getName());
 
-        $output = $this->execHidden($command);
+        $output = CommandRunner::execCombined('sc', ['query', $this->getName()]);
         $duration = round(microtime(true) - $startTime, 3);
 
         Util::logTrace("sc.exe query completed in " . $duration . "s");
@@ -766,8 +718,7 @@ class Win32Service
             Util::logTrace("Service exists, getting full details");
 
             // Use sc qc to get configuration details (including path)
-            $configCommand = 'sc qc "' . $this->getName() . '"';
-            $configOutput = $this->execHidden($configCommand);
+            $configOutput = CommandRunner::execCombined('sc', ['qc', $this->getName()]);
 
             if ($configOutput !== null && $configOutput !== false && preg_match('/BINARY_PATH_NAME\s*:\s*(.+)/i', $configOutput, $matches)) {
                 $serviceInfo[self::VBS_PATH_NAME] = trim($matches[1]);


### PR DESCRIPTION
### **User description**
---

### Summary

This pull request refactors and optimizes various parts of the codebase for improved maintainability, efficiency, and security.

### Details of Changes

1. **Refactored service-specific logic**: Updated to use `getBinByName` for better maintainability and reduced redundancy.
2. **Input sanitization improvement**: Removed unnecessary `stripslashes` from `GET` and `POST` inputs in `class.util.php`.
3. **COM connection caching**: Introduced caching and centralized reset methods for WMI and WScript.Shell COM objects within `Win32Native`, reducing overhead and improving efficiency.
4. **Standardized command execution**: Added `CommandRunner` class for consistent PHP shell execution. Refactored existing shell command calls to utilize this class, improving maintainability, security, and logging.

### Checklist

- [ ] Proper testing has been conducted for all changes.
- [ ] Documentation has been updated as necessary.
- [ ] CI/CD pipelines pass without issues.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduce `CommandRunner` class for centralized, auditable shell execution with consistent argument escaping and logging across all PHP shell primitives (proc_open, popen, shell_exec)

- Implement COM connection caching in `Win32Native` with automatic reset on exceptions to reduce object creation overhead and prevent reuse of broken instances

- Refactor service-specific branching logic to use `getBinByName()` method, eliminating redundant if-elseif chains across multiple action classes

- Remove unnecessary `stripslashes()` from GET and POST input sanitization in `class.util.php` to improve security


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shell Execution<br/>proc_open, popen,<br/>shell_exec"] -->|"Unified via"| B["CommandRunner<br/>Class"]
  B -->|"Consistent<br/>escaping & logging"| C["Auditable<br/>Execution Points"]
  D["COM Objects<br/>WMI, WScript.Shell"] -->|"Cached via"| E["Win32Native<br/>Static Methods"]
  E -->|"Auto-reset<br/>on exception"| F["Fresh Connections<br/>on Failure"]
  G["Service-specific<br/>if-elseif chains"] -->|"Replaced by"| H["getBinByName<br/>Lookup"]
  H -->|"Reduces<br/>redundancy"| I["Maintainable<br/>Code"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>class.commandrunner.php</strong><dd><code>New CommandRunner class for unified shell execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-d3e64529433c4ac6205e9a25a7274d9ac5fb74d513f8189819cbb0bd936d2bd4">+190/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>class.win32native.php</strong><dd><code>Add COM connection caching and automatic reset on exceptions</code></dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-2e96b9d95c56a5d8ff6d46d75492f536850318b0f259c52c0600972bc89189ec">+93/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>class.bins.php</strong><dd><code>Add getBinByName method for service lookup by display name</code></dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-4be80bf0cd7ebc913868969458c3f68c9589558e479ba1ef89ee754c26436a9a">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>class.action.changePort.php</strong><dd><code>Refactor service detection to use getBinByName method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-521f38080cc5b1936247b68c24396bc4150cef0bc667e82b7345b1950743d414">+11/-36</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>class.action.checkPort.php</strong><dd><code>Refactor service detection to use getBinByName method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-5eb0af0162939c1ef09a9457db9cf798c7b611222d5c54f02d5347410e80f5b2">+8/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>class.action.enable.php</strong><dd><code>Refactor service detection to use getBinByName method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-993119c9272101f71908be1f41e3e4c6cdb96af5cbad080cbf6ca03230563d5e">+3/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>class.action.switchVersion.php</strong><dd><code>Refactor service reference refresh to use getBinByName</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-82396a70518c0eee19639a0d6fc13da6a13fd57aca71cbb8eb2d020bf6c6eb24">+10/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>class.action.loading.php</strong><dd><code>Replace popen background execution with CommandRunner</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-86ce02021c0e1e88bed59f6a6acd0dded7b50655d62c2089a9989d9e5181b98b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>class.core.php</strong><dd><code>Migrate 7zip extraction to use CommandRunner for streaming</code></dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-054c1637f705cfc626b10bb80e0d3869e005dbc4663eb468305bf1507e95e888">+38/-89</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>class.win32service.php</strong><dd><code>Replace execHidden method with CommandRunner.execCombined</code></dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-c049a530f4820f9af791d858ba41c1aa79ab585638ffdb3cfd25a1c7db420150">+3/-52</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>class.util.php</strong><dd><code>Remove stripslashes from GET/POST sanitization and use CommandRunner </code><br><code>for shell_exec</code></dd></td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/202/files#diff-4cf3daa5765ea02c1921901194cf0cfb0786be4ce5b34673e7b6701e0bf37b46">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

