### PR TITLE
Handle symlink removal on Windows for directory junctions

### DIFF
--- a/core/classes/class.symlinks.php
+++ b/core/classes/class.symlinks.php
@@ -132,9 +132,11 @@ class Symlinks
             return false;
         }
 
-        // If it's a symlink, use unlink (works for symlinks regardless of target)
+        // If it's a symlink, remove it appropriately.
+        // On Windows, directory junctions report as is_link() === true but require rmdir(), not unlink().
         if (self::isSymlink($path)) {
-            if (@unlink($path)) {
+            $removed = is_dir($path) ? @rmdir($path) : @unlink($path);
+            if ($removed) {
                 Log::debug('Safely removed symlink: ' . $path);
                 return true;
             } else {


### PR DESCRIPTION
---

### Description

This pull request updates the logic for handling symlink removal on Windows. It ensures that `rmdir()` is used for removing directory junctions in a way that accounts for platform-specific support.

### Related Issues

_No related issues were linked to this pull request._

### Changes Made

- Implemented `rmdir()` for removing directory junctions on Windows.
- Updated logic to handle symlink removal tailored for the Windows platform.

### Checklist

- [ ] Tests have been added and pass locally.
- [ ] Documentation has been updated as needed.
- [ ] Changes have been reviewed by at least one other contributor.
