### PR TITLE
Register Nerd Font in Windows registry for PowerShell console and fix console window title handling

### DIFF
--- a/core/classes/tools/class.tool.powershell.php
+++ b/core/classes/tools/class.tool.powershell.php
@@ -158,9 +158,9 @@ class ToolPowerShell extends Module
      */
     public function getShell($args = null) {
         if (empty($args)) {
-            return 'cmd /k &quot;' . Util::formatWindowsPath($this->launchExe) . '&quot;';
+            return 'cmd /c &quot;' . Util::formatWindowsPath($this->launchExe) . '&quot;';
         } else {
-            return 'cmd /k &quot;&quot;' . Util::formatWindowsPath($this->getLaunchExe()) . '&quot; &amp; ' . Util::formatWindowsPath($args) . '&quot;';
+            return 'cmd /c &quot;&quot;' . Util::formatWindowsPath($this->getLaunchExe()) . '&quot; &amp; ' . Util::formatWindowsPath($args) . '&quot;';
         }
     }
 
@@ -170,7 +170,7 @@ class ToolPowerShell extends Module
      * @return string The default tab title.
      */
     public function getTabTitleDefault() {
-        return 'Bearsampp Powershell Console';
+        return 'Bearsampp PowerShell Console';
     }
 
     /**

--- a/core/classes/tpls/app/class.tpl.app.tools.php
+++ b/core/classes/tpls/app/class.tpl.app.tools.php
@@ -132,7 +132,10 @@ class TplAppTools
         // Console
         $resultItems .= TplAestan::getItemPowerShell(
             $bearsamppLang->getValue(Lang::CONSOLE),
-            TplAestan::GLYPH_POWERSHELL
+            TplAestan::GLYPH_POWERSHELL,
+            null,
+            $bearsamppTools->getPowerShell()->getTabTitleDefault(),
+            $bearsamppRoot->getRootPath()
         ) . PHP_EOL;
 
         // HostsEditor

--- a/core/classes/tpls/class.tpl.aestan.php
+++ b/core/classes/tpls/class.tpl.aestan.php
@@ -151,10 +151,11 @@ class TplAestan
         // Build the parameters using Windows Terminal switches
         $params = '';
         
-        // Add title if provided (using -w for compatibility)
-        if ($title != null) {
-            $params .= '--title ""' . $title . '""';
+        // Add title (using -w for compatibility)
+        if ($title == null) {
+            $title = $bearsamppTools->getPowerShell()->getTabTitleDefault();
         }
+        $params .= '--title ""' . $title . '""';
         
         // Add starting directory if provided (using -d for compatibility)
         if ($initDir != null) {

--- a/core/classes/tpls/class.tpl.aestan.php
+++ b/core/classes/tpls/class.tpl.aestan.php
@@ -142,39 +142,38 @@ class TplAestan
     {
         global $bearsamppTools;
 
-        // PowerShell uses the launch batch file which handles the command execution
-        // We use Windows Terminal command-line arguments:
-        // --title or -w for window title
-        // --startingDirectory or -d for starting directory
-        $launchExe = $bearsamppTools->getPowerShell()->getLaunchExe();
-        
-        // Build the parameters using Windows Terminal switches
-        $params = '';
-        
-        // Add title (using -w for compatibility)
-        if ($title == null) {
+        if ($title === null) {
             $title = $bearsamppTools->getPowerShell()->getTabTitleDefault();
         }
-        $params .= '--title ""' . $title . '""';
-        
-        // Add starting directory if provided (using -d for compatibility)
-        if ($initDir != null) {
-            if (!empty($params)) $params .= ' ';
-            $params .= '--startingDirectory ""' . $initDir . '""';
-        }
-        
-        // Add command to execute if provided
-        if ($command != null) {
-            if (!empty($params)) $params .= ' ';
-            $params .= '--command ""' . $command . '""';
+
+        // Launch pwsh.exe directly — no powershell.bat wrapper, no cmd.exe, no flashing window.
+        // Registry font settings are pre-written during reload by TplPowerShell::process().
+        $pwsh = $bearsamppTools->getPowerShell()->getExe();
+        $profilePath = Util::formatWindowsPath($bearsamppTools->getPowerShell()->getConf());
+
+        // Build the inline PowerShell -Command string.
+        // Single-quoted strings are used for paths/titles so backslashes need no escaping.
+        // $Host and [Console] are PowerShell syntax; no shell variable expansion occurs here
+        // because Aestan calls CreateProcess directly (no cmd.exe intermediary).
+        $psCommand = '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;' .
+                     '[Console]::InputEncoding=[System.Text.Encoding]::UTF8;' .
+                     '$Host.UI.RawUI.WindowTitle=\'' . $title . '\';';
+
+        if ($command !== null) {
+            $psCommand .= $command . ';';
         }
 
-        return self::getItemExe(
-            $caption,
-            $launchExe,
-            $glyph,
-            $params
-        );
+        $psCommand .= '. \'' . $profilePath . '\'';
+
+        // Build pwsh.exe argument string using Aestan's "" escaping for embedded double quotes.
+        // -WorkingDirectory sets the initial directory (PowerShell 7+), avoiding Set-Location.
+        $params = '-NoExit -NoProfile';
+        if ($initDir !== null) {
+            $params .= ' -WorkingDirectory ""' . $initDir . '""';
+        }
+        $params .= ' -Command ""' . $psCommand . '""';
+
+        return self::getItemExe($caption, $pwsh, $glyph, $params);
     }
 
     /**

--- a/core/classes/tpls/class.tpl.powershell.php
+++ b/core/classes/tpls/class.tpl.powershell.php
@@ -109,8 +109,22 @@ class TplPowerShell
 
         // Write and import the .reg file in a single process — zero flashing windows
         $tmpReg = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bearsampp_console_font.reg';
-        file_put_contents($tmpReg, $regContent);
-        @exec("reg import \"$tmpReg\"");
+
+        $bytes = file_put_contents($tmpReg, $regContent);
+        if ($bytes === false || $bytes === 0) {
+            return false;
+        }
+
+        $cmd = 'reg import "' . $tmpReg . '"';
+        $output = [];
+        $exitCode = 0;
+        exec($cmd, $output, $exitCode);
+
+        @unlink($tmpReg);
+
+        if ($exitCode !== 0) {
+            return false;
+        }
 
         return true;
     }

--- a/core/classes/tpls/class.tpl.powershell.php
+++ b/core/classes/tpls/class.tpl.powershell.php
@@ -49,8 +49,88 @@ class TplPowerShell
      */
     public static function process()
     {
-        // PowerShell uses profile scripts (Microsoft.PowerShell_profile.ps1)
-        // and Oh My Posh for configuration - no processing needed here
+        global $bearsamppTools;
+
+        $fontName = 'CaskaydiaMono NF'; // Default Nerd Font
+
+        // Get all possible titles
+        $titles = [];
+        $titles[] = $bearsamppTools->getPowerShell()->getTabTitleDefault();
+        $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePowershell();
+        $titles[] = 'Console';
+        $titles[] = 'Bearsampp Powershell Console'; // Fallback casing
+
+        // Add tool titles (these might include versions)
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePear(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleMysql(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleMariadb(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePostgresql(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleGit(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleNodejs(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleComposer(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePython(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleRuby(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePerl(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleGhostscript(); } catch (Exception $e) {}
+        try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleNgrok(); } catch (Exception $e) {}
+
+        // Pre-register each title in the registry
+        foreach (array_unique($titles) as $title) {
+            if (empty($title)) continue;
+            
+            $key = "HKCU\\Console\\" . $title;
+            @exec("reg add \"$key\" /v FaceName /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+            @exec("reg add \"$key\" /v FontFamily /t REG_DWORD /d 54 /f >nul 2>&1");
+            @exec("reg add \"$key\" /v FontSize /t REG_DWORD /d 0x00100000 /f >nul 2>&1");
+            @exec("reg add \"$key\" /v FontWeight /t REG_DWORD /d 400 /f >nul 2>&1");
+            @exec("reg add \"$key\" /v CodePage /t REG_DWORD /d 65001 /f >nul 2>&1");
+            @exec("reg add \"$key\" /v ScreenBufferSize /t REG_DWORD /d 0x0bb8006e /f >nul 2>&1");
+            @exec("reg add \"$key\" /v WindowSize /t REG_DWORD /d 0x001e006e /f >nul 2>&1");
+        }
+
+        // Also pre-register generic/short titles to be safe
+        $shortTitles = ["Composer", "Ghostscript", "ngrok", "PEAR", "Perl", "Ruby", "Git", "Python", "MariaDB", "MySQL", "PostgreSQL", "Node.js"];
+        foreach ($shortTitles as $st) {
+            $key = "HKCU\\Console\\" . $st;
+            @exec("reg add \"$key\" /v FaceName /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+            @exec("reg add \"$key\" /v FontFamily /t REG_DWORD /d 54 /f >nul 2>&1");
+            @exec("reg add \"$key\" /v CodePage /t REG_DWORD /d 65001 /f >nul 2>&1");
+        }
+
+        // Also set global default
+        @exec("reg add \"HKCU\\Console\" /v FaceName /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+        @exec("reg add \"HKCU\\Console\" /v FontFamily /t REG_DWORD /d 54 /f >nul 2>&1");
+        @exec("reg add \"HKCU\\Console\" /v CodePage /t REG_DWORD /d 65001 /f >nul 2>&1");
+
+        // Register as valid console font in multiple slots to ensure it's picked up
+        // We use HKLM because conhost.exe (launched by Aestan Tray Menu) often ignores HKCU for font registration
+        $ttKey = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Console\\TrueTypeFont";
+        $fontsKey = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts";
+        
+        // Ensure the font is actually registered in HKLM Fonts list so conhost sees it
+        // We check HKCU first to see where it is installed
+        $fontPath = '';
+        $output = [];
+        @exec("reg query \"HKCU\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\" /v \"$fontName (TrueType)\"", $output);
+        foreach ($output as $line) {
+            if (preg_match('/REG_SZ\s+(.*)$/', $line, $matches)) {
+                $fontPath = trim($matches[1]);
+                break;
+            }
+        }
+        
+        if ($fontPath) {
+            @exec("reg add \"$fontsKey\" /v \"$fontName (TrueType)\" /t REG_SZ /d \"$fontPath\" /f >nul 2>&1");
+        }
+
+        @exec("reg add \"$ttKey\" /v \"000\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+        @exec("reg add \"$ttKey\" /v \"0000\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+        
+        $ttKeyHkcu = "HKCU\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Console\\TrueTypeFont";
+        @exec("reg add \"$ttKeyHkcu\" /v \"0\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+        @exec("reg add \"$ttKeyHkcu\" /v \"00\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+        @exec("reg add \"$ttKeyHkcu\" /v \"000\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+
         return true;
     }
 

--- a/core/classes/tpls/class.tpl.powershell.php
+++ b/core/classes/tpls/class.tpl.powershell.php
@@ -53,14 +53,13 @@ class TplPowerShell
 
         $fontName = 'CaskaydiaMono NF'; // Default Nerd Font
 
-        // Get all possible titles
+        // Collect all console window titles that need font configuration
         $titles = [];
         $titles[] = $bearsamppTools->getPowerShell()->getTabTitleDefault();
         $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePowershell();
         $titles[] = 'Console';
         $titles[] = 'Bearsampp Powershell Console'; // Fallback casing
 
-        // Add tool titles (these might include versions)
         try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitlePear(); } catch (Exception $e) {}
         try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleMysql(); } catch (Exception $e) {}
         try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleMariadb(); } catch (Exception $e) {}
@@ -74,62 +73,44 @@ class TplPowerShell
         try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleGhostscript(); } catch (Exception $e) {}
         try { $titles[] = $bearsamppTools->getPowerShell()->getTabTitleNgrok(); } catch (Exception $e) {}
 
-        // Pre-register each title in the registry
-        foreach (array_unique($titles) as $title) {
-            if (empty($title)) continue;
-            
-            $key = "HKCU\\Console\\" . $title;
-            @exec("reg add \"$key\" /v FaceName /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-            @exec("reg add \"$key\" /v FontFamily /t REG_DWORD /d 54 /f >nul 2>&1");
-            @exec("reg add \"$key\" /v FontSize /t REG_DWORD /d 0x00100000 /f >nul 2>&1");
-            @exec("reg add \"$key\" /v FontWeight /t REG_DWORD /d 400 /f >nul 2>&1");
-            @exec("reg add \"$key\" /v CodePage /t REG_DWORD /d 65001 /f >nul 2>&1");
-            @exec("reg add \"$key\" /v ScreenBufferSize /t REG_DWORD /d 0x0bb8006e /f >nul 2>&1");
-            @exec("reg add \"$key\" /v WindowSize /t REG_DWORD /d 0x001e006e /f >nul 2>&1");
-        }
-
-        // Also pre-register generic/short titles to be safe
+        // Also include generic/short titles
         $shortTitles = ["Composer", "Ghostscript", "ngrok", "PEAR", "Perl", "Ruby", "Git", "Python", "MariaDB", "MySQL", "PostgreSQL", "Node.js"];
-        foreach ($shortTitles as $st) {
-            $key = "HKCU\\Console\\" . $st;
-            @exec("reg add \"$key\" /v FaceName /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-            @exec("reg add \"$key\" /v FontFamily /t REG_DWORD /d 54 /f >nul 2>&1");
-            @exec("reg add \"$key\" /v CodePage /t REG_DWORD /d 65001 /f >nul 2>&1");
+        $allTitles = array_unique(array_merge($titles, $shortTitles));
+
+        // Build a single .reg file with all HKCU Console font settings.
+        // This replaces ~140 individual exec("reg add ...") calls, each of which
+        // would spawn a separate process and potentially flash a console window.
+        $regContent = "Windows Registry Editor Version 5.00\r\n";
+
+        // Global HKCU\Console defaults
+        $regContent .= "\r\n[HKEY_CURRENT_USER\\Console]\r\n";
+        $regContent .= '"FaceName"="' . $fontName . '"' . "\r\n";
+        $regContent .= '"FontFamily"=dword:00000036' . "\r\n";
+        $regContent .= '"CodePage"=dword:0000fde9' . "\r\n";
+
+        // Per-title settings
+        foreach ($allTitles as $title) {
+            if (empty($title)) continue;
+            $regContent .= "\r\n[HKEY_CURRENT_USER\\Console\\" . $title . "]\r\n";
+            $regContent .= '"FaceName"="' . $fontName . '"' . "\r\n";
+            $regContent .= '"FontFamily"=dword:00000036' . "\r\n";
+            $regContent .= '"FontSize"=dword:00100000' . "\r\n";
+            $regContent .= '"FontWeight"=dword:00000190' . "\r\n";
+            $regContent .= '"CodePage"=dword:0000fde9' . "\r\n";
+            $regContent .= '"ScreenBufferSize"=dword:0bb8006e' . "\r\n";
+            $regContent .= '"WindowSize"=dword:001e006e' . "\r\n";
         }
 
-        // Also set global default
-        @exec("reg add \"HKCU\\Console\" /v FaceName /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-        @exec("reg add \"HKCU\\Console\" /v FontFamily /t REG_DWORD /d 54 /f >nul 2>&1");
-        @exec("reg add \"HKCU\\Console\" /v CodePage /t REG_DWORD /d 65001 /f >nul 2>&1");
+        // Register as a valid TrueType console font (HKCU only — no elevation needed)
+        $regContent .= "\r\n[HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Console\\TrueTypeFont]\r\n";
+        $regContent .= '"0"="' . $fontName . '"' . "\r\n";
+        $regContent .= '"00"="' . $fontName . '"' . "\r\n";
+        $regContent .= '"000"="' . $fontName . '"' . "\r\n";
 
-        // Register as valid console font in multiple slots to ensure it's picked up
-        // We use HKLM because conhost.exe (launched by Aestan Tray Menu) often ignores HKCU for font registration
-        $ttKey = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Console\\TrueTypeFont";
-        $fontsKey = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts";
-        
-        // Ensure the font is actually registered in HKLM Fonts list so conhost sees it
-        // We check HKCU first to see where it is installed
-        $fontPath = '';
-        $output = [];
-        @exec("reg query \"HKCU\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\" /v \"$fontName (TrueType)\"", $output);
-        foreach ($output as $line) {
-            if (preg_match('/REG_SZ\s+(.*)$/', $line, $matches)) {
-                $fontPath = trim($matches[1]);
-                break;
-            }
-        }
-        
-        if ($fontPath) {
-            @exec("reg add \"$fontsKey\" /v \"$fontName (TrueType)\" /t REG_SZ /d \"$fontPath\" /f >nul 2>&1");
-        }
-
-        @exec("reg add \"$ttKey\" /v \"000\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-        @exec("reg add \"$ttKey\" /v \"0000\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-        
-        $ttKeyHkcu = "HKCU\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Console\\TrueTypeFont";
-        @exec("reg add \"$ttKeyHkcu\" /v \"0\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-        @exec("reg add \"$ttKeyHkcu\" /v \"00\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
-        @exec("reg add \"$ttKeyHkcu\" /v \"000\" /t REG_SZ /d \"$fontName\" /f >nul 2>&1");
+        // Write and import the .reg file in a single process — zero flashing windows
+        $tmpReg = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bearsampp_console_font.reg';
+        file_put_contents($tmpReg, $regContent);
+        @exec("reg import \"$tmpReg\"");
 
         return true;
     }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Optimize PowerShell launch by directly executing pwsh.exe instead of cmd.exe wrapper

- Pre-register CaskaydiaMono NF font in Windows registry for all console titles

- Fix console window title casing from "Powershell" to "PowerShell"

- Streamline font configuration into single .reg file import to eliminate window flashing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PowerShell Launch"] -->|"Direct pwsh.exe"| B["No cmd.exe wrapper"]
  B -->|"Faster execution"| C["Reduced overhead"]
  D["Font Configuration"] -->|"Unified .reg file"| E["Single registry import"]
  E -->|"No window flashing"| F["Improved UX"]
  G["Console Titles"] -->|"Pre-registered"| H["All tools supported"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.tool.powershell.php</strong><dd><code>Fix shell command and title casing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/tools/class.tool.powershell.php

<ul><li>Changed shell command from <code>cmd /k</code> to <code>cmd /c</code> to prevent console window <br>from staying open<br> <li> Fixed default tab title casing from "Powershell" to "PowerShell"</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/208/files#diff-89ee46ca840a9b2300d14e8b6622a86c8ea513dd2bf5e730dcfff3e133e8640f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.tpl.app.tools.php</strong><dd><code>Pass title and root path to PowerShell menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/tpls/app/class.tpl.app.tools.php

<ul><li>Added default tab title parameter to PowerShell menu item<br> <li> Added root path parameter for proper directory initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/208/files#diff-c652ad18c42fcdf4d5763baa4439e6c4578f2cffbcc8d367f29961b7792775fc">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.tpl.aestan.php</strong><dd><code>Refactor to direct pwsh.exe launch without cmd.exe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/tpls/class.tpl.aestan.php

<ul><li>Replaced Windows Terminal command-line arguments with direct pwsh.exe <br>execution<br> <li> Implemented inline PowerShell -Command with UTF-8 encoding and window <br>title setting<br> <li> Changed from batch file wrapper to direct process launch with <br>-WorkingDirectory parameter<br> <li> Simplified parameter building to use -NoExit -NoProfile flags</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/208/files#diff-c0e7fcbed80ac0bf9d0d8a678595db3eb1c3372db864496f82b2a829cc4632a6">+28/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.tpl.powershell.php</strong><dd><code>Consolidate font registry configuration into single .reg file</code></dd></summary>
<hr>

core/classes/tpls/class.tpl.powershell.php

<ul><li>Implemented unified .reg file generation for all console titles and <br>font settings<br> <li> Collects all PowerShell console window titles from tools and generic <br>names<br> <li> Registers CaskaydiaMono NF font in Windows registry with proper <br>TrueType settings<br> <li> Imports single .reg file via reg.exe instead of multiple individual <br>registry calls<br> <li> Eliminates window flashing by consolidating registry operations into <br>one process</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/208/files#diff-effa2cf742876452e4e171ffc25f15e4ad67e37195393803d05a7a7fca757c55">+77/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

