### PR TITLE
Refactor utility methods: simplify folder listing, consolidate GitHub URL generation, and add encoding conversion helper

### DIFF
--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -351,7 +351,7 @@ class Util
         while (false !== ($file = readdir($handle))) {
             $filePath = $path . '/' . $file;
             if ($file != '.' && $file != '..' && is_dir($filePath) && $file != 'current') {
-                $result[] = str_replace(basename($path), '', $file);
+                $result[] = $file;
             }
         }
 
@@ -663,6 +663,23 @@ class Util
         $data = file_get_contents($path);
 
         return 'data:image/' . $type . ';base64,' . base64_encode($data);
+    }
+
+    /**
+     * Converts data between UTF-8 and Windows-1252 encodings.
+     *
+     * @param   string  $data      The data to convert.
+     * @param   string  $direction The conversion direction: 'to_cp1252' or 'to_utf8'. Defaults to 'to_cp1252'.
+     *
+     * @return string The converted data.
+     */
+    public static function convertEncoding($data, $direction = 'to_cp1252')
+    {
+        if ($direction === 'to_utf8') {
+            return self::cp1252ToUtf8($data);
+        } else {
+            return self::utf8ToCp1252($data);
+        }
     }
 
     /**
@@ -1391,24 +1408,11 @@ class Util
     }
 
     /**
-     * Constructs a website URL without UTM parameters.
-     *
-     * @param   string  $path      Optional path to append to the base URL.
-     * @param   string  $fragment  Optional fragment to append to the URL.
-     *
-     * @return string The constructed URL without UTM parameters.
-     */
-    public static function getWebsiteUrlNoUtm($path = '', $fragment = '')
-    {
-        return self::getWebsiteUrl($path, $fragment, false);
-    }
-
-    /**
      * Constructs a complete website URL with optional path, fragment, and UTM source parameters.
      *
      * @param   string  $path       Optional path to append to the base URL.
      * @param   string  $fragment   Optional fragment to append to the URL.
-     * @param   bool    $utmSource  Whether to include UTM source parameters.
+     * @param   bool    $utmSource  Whether to include UTM source parameters. Defaults to true.
      *
      * @return string The constructed URL.
      */
@@ -1428,6 +1432,19 @@ class Util
         }
 
         return $url;
+    }
+
+    /**
+     * Constructs a website URL without UTM parameters.
+     *
+     * @param   string  $path      Optional path to append to the base URL.
+     * @param   string  $fragment  Optional fragment to append to the URL.
+     *
+     * @return string The constructed URL without UTM parameters.
+     */
+    public static function getWebsiteUrlNoUtm($path = '', $fragment = '')
+    {
+        return self::getWebsiteUrl($path, $fragment, false);
     }
 
     /**
@@ -1890,206 +1907,47 @@ class Util
     }
 
     /**
-     * Constructs a GitHub user URL with an optional path.
+     * Generates various GitHub URLs based on the specified type.
      *
-     * @param   string|null  $part  Optional path to append to the URL.
-     *
-     * @return string The full GitHub user URL.
+     * @param string $type The type of URL ('user', 'repo', 'raw').
+     * @param string $user The GitHub username.
+     * @param string|null $repo The repository name (required for 'repo' and 'raw' types).
+     * @param string|null $branch The branch name (required for 'raw' type).
+     * @param string|null $path The file path (required for 'raw' type).
+     * @return string|false The generated URL or false on invalid input.
      */
-    public static function getGithubUserUrl($part = null)
-    {
-        $part = !empty($part) ? '/' . $part : null;
-
-        return 'https://github.com/' . APP_GITHUB_USER . $part;
-    }
-
-    /**
-     * Constructs a GitHub repository URL with an optional path.
-     *
-     * @param   string|null  $part  Optional path to append to the URL.
-     *
-     * @return string The full GitHub repository URL.
-     */
-    public static function getGithubUrl($part = null)
-    {
-        $part = !empty($part) ? '/' . $part : null;
-
-        return self::getGithubUserUrl(APP_GITHUB_REPO . $part);
-    }
-
-    /**
-     * Constructs a URL for raw content from a GitHub repository.
-     *
-     * @param   string  $file  The file path to append to the base URL.
-     *
-     * @return string The full URL to the raw content on GitHub.
-     */
-    public static function getGithubRawUrl($file)
-    {
-        $file = !empty($file) ? '/' . $file : null;
-
-        return 'https://raw.githubusercontent.com/' . APP_GITHUB_USER . '/' . APP_GITHUB_REPO . '/main' . $file;
-    }
-
-    /**
-     * Retrieves a list of folders from a specified directory, excluding certain directories.
-     *
-     * @param   string  $path  The directory path from which to list folders.
-     *
-     * @return array|bool An array of folder names, or false if the directory cannot be opened.
-     */
-    public static function getFolderList($path)
-    {
-        $result = array();
-
-        $handle = @opendir($path);
-        if (!$handle) {
+    public static function getGithubUrl($type, $user, $repo = null, $branch = null, $path = null) {
+        // Basic validation
+        if (empty($user) || !is_string($user)) {
             return false;
         }
-
-        while (false !== ($file = readdir($handle))) {
-            $filePath = $path . '/' . $file;
-            if ($file != '.' && $file != '..' && is_dir($filePath) && $file != 'current') {
-                $result[] = $file;
-            }
-        }
-
-        closedir($handle);
-
-        return $result;
-    }
-
-    /**
-     * Retrieves and formats environment paths from a data file.
-     * Paths are verified to be directories and formatted to Unix style.
-     * Warnings are logged for paths that do not exist.
-     *
-     * @return string A semicolon-separated string of formatted environment paths.
-     * @global object $bearsamppRoot Global object containing root path methods.
-     */
-    public static function getNssmEnvPaths()
-    {
-        global $bearsamppRoot;
-
-        $result           = '';
-        $nssmEnvPathsFile = $bearsamppRoot->getRootPath() . '/nssmEnvPaths.dat';
-
-        if (is_file($nssmEnvPathsFile)) {
-            $paths = explode(PHP_EOL, file_get_contents($nssmEnvPathsFile));
-            foreach ($paths as $path) {
-                $path = trim($path);
-                if (stripos($path, ':') === false) {
-                    $path = $bearsamppRoot->getRootPath() . '/' . $path;
+        
+        // URL-encode components to handle special characters
+        $user = urlencode($user);
+        
+        switch ($type) {
+            case 'user':
+                return "https://github.com/{$user}";
+            
+            case 'repo':
+                if (empty($repo) || !is_string($repo)) {
+                    return false;
                 }
-                if (is_dir($path)) {
-                    $result .= UtilPath::formatUnixPath($path) . ';';
-                } else {
-                    Log::warning('Path not found in nssmEnvPaths.dat: ' . $path);
+                $repo = urlencode($repo);
+                return "https://github.com/{$user}/{$repo}";
+            
+            case 'raw':
+                if (empty($repo) || empty($branch) || empty($path) || !is_string($repo) || !is_string($branch) || !is_string($path)) {
+                    return false;
                 }
-            }
+                $repo = urlencode($repo);
+                $branch = urlencode($branch);
+                $path = urlencode($path);
+                return "https://raw.githubusercontent.com/{$user}/{$repo}/{$branch}/{$path}";
+            
+            default:
+                return false; // Invalid type
         }
-
-        return $result;
-    }
-
-    /**
-     * Opens a file with a given caption and content in the default text editor.
-     * The file is created in a temporary directory with a unique name.
-     *
-     * @param   string  $caption            The filename to use when saving the content.
-     * @param   string  $content            The content to write to the file.
-     *
-     * @global object   $bearsamppRoot      Global object to access temporary path.
-     * @global object   $bearsamppConfig    Global configuration object.
-     * @global object   $bearsamppWinbinder Global object to execute external programs.
-     */
-    public static function openFileContent($caption, $content)
-    {
-        global $bearsamppRoot, $bearsamppConfig, $bearsamppWinbinder;
-
-        $folderPath = $bearsamppRoot->getTmpPath() . '/openFileContent-' . UtilString::random();
-        if (!is_dir($folderPath)) {
-            mkdir($folderPath, 0777, true);
-        }
-
-        $filepath = UtilPath::formatWindowsPath($folderPath . '/' . $caption);
-        file_put_contents($filepath, $content);
-
-        $bearsamppWinbinder->exec($bearsamppConfig->getNotepad(), '"' . $filepath . '"');
-    }
-
-    /**
-     * Decrypts a file encrypted with a specified method and returns the content.
-     *
-     * @return string|false Decrypted content or false on failure.
-     */
-    public static function decryptFile()
-    {
-        global $bearsamppCore, $bearsamppConfig;
-
-        $stringfile = $bearsamppCore->getResourcesPath() . '/string.dat';
-        $encryptedFile = $bearsamppCore->getResourcesPath() . '/github.dat';
-        $method        = 'AES-256-CBC'; // The same encryption method used
-
-        // Get key string
-        $stringPhrase = @file_get_contents($stringfile);
-        if ($stringPhrase === false) {
-            Log::debug("Failed to read the file at path: {$stringfile}");
-
-            return false;
-        }
-
-        $stringKey = convert_uudecode($stringPhrase);
-
-        // Read the encrypted data from the file
-        $encryptedData = file_get_contents($encryptedFile);
-        if ($encryptedData === false) {
-            Log::debug("Failed to read the file at path: {$encryptedFile}");
-
-            return false;
-        }
-
-        // Decode the base64 encoded data
-        $data = base64_decode($encryptedData);
-        if ($data === false) {
-            Log::debug("Failed to decode the data from path: {$encryptedFile}");
-
-            return false;
-        }
-
-        // Extract the IV which was prepended to the encrypted data
-        $ivLength  = openssl_cipher_iv_length($method);
-        $iv        = substr($data, 0, $ivLength);
-        $encrypted = substr($data, $ivLength);
-
-        // Decrypt the data
-        $decrypted = openssl_decrypt($encrypted, $method, $stringKey, 0, $iv);
-        if ($decrypted === false) {
-            Log::debug("Decryption failed for data from path: {$encryptedFile}");
-
-            return false;
-        }
-
-        return $decrypted;
-    }
-
-    /**
-     * Sets up a cURL header array using a decrypted GitHub Personal Access Token.
-     *
-     * @return array The header array for cURL with authorization and other necessary details.
-     */
-    public static function setupCurlHeaderWithToken()
-    {
-        // Usage
-        global $bearsamppCore, $bearsamppConfig;
-        $Token = self::decryptFile();
-
-        return [
-            'Accept: application/vnd.github+json',
-            'Authorization: Token ' . $Token,
-            'User-Agent: ' . APP_GITHUB_USERAGENT,
-            'X-GitHub-Api-Version: 2022-11-28'
-        ];
     }
 
     /**

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1917,14 +1917,14 @@ class Util
     /**
      * Generates various GitHub URLs based on the specified type.
      *
-     * @param string $type The type of URL ('user', 'repo', 'raw').
-     * @param string $user The GitHub username.
+     * @param string $type The type of URL ('user', 'repo', 'raw'). Defaults to 'user'.
+     * @param string $user The GitHub username. Defaults to 'Bearsampp'.
      * @param string|null $repo The repository name (required for 'repo' and 'raw' types).
      * @param string|null $branch The branch name (required for 'raw' type).
      * @param string|null $path The file path (required for 'raw' type).
      * @return string|false The generated URL or false on invalid input.
      */
-    public static function getGithubUrl($type, $user, $repo = null, $branch = null, $path = null) {
+    public static function getGithubUrl($type = 'user', $user = 'Bearsampp', $repo = null, $branch = null, $path = null) {
         // Basic validation
         if (empty($user) || !is_string($user)) {
             return false;
@@ -1959,6 +1959,16 @@ class Util
     }
 
     /**
+     * Gets the GitHub user URL for Bearsampp.
+     *
+     * @return string The GitHub user URL.
+     */
+    public static function getGithubUserUrl()
+    {
+        return self::getGithubUrl('user', 'Bearsampp');
+    }
+
+    /**
      * Checks the current state of the internet connection.
      *
      * This method attempts to reach a well-known website (e.g., www.google.com) to determine the state of the internet connection.
@@ -1976,5 +1986,116 @@ class Util
         } else {
             return false; // Internet connection is not active
         }
+    }
+
+    /**
+     * Gets the list of folders in the specified path.
+     *
+     * @param   string  $path  The directory path to scan for folders.
+     *
+     * @return array|false Returns a sorted array of folder names, or false if the directory cannot be opened.
+     */
+    public static function getFolderList($path)
+    {
+        $result = array();
+
+        $handle = @opendir($path);
+        if (!$handle) {
+            return false;
+        }
+
+        while (false !== ($file = readdir($handle))) {
+            $filePath = $path . '/' . $file;
+            if ($file != '.' && $file != '..' && is_dir($filePath) && $file != 'current') {
+                $result[] = $file;
+            }
+        }
+
+        closedir($handle);
+        natcasesort($result);
+
+        return $result;
+    }
+
+    /**
+     * Gets the NSSM environment paths.
+     *
+     * @return string The NSSM environment paths string.
+     */
+    public static function getNssmEnvPaths()
+    {
+        global $bearsamppBins, $bearsamppTools;
+
+        $paths = '';
+
+        // Add paths for enabled bins
+        if ($bearsamppBins->getApache()->isEnable()) {
+            $paths .= $bearsamppBins->getApache()->getSymlinkPath() . '/bin;';
+        }
+        if ($bearsamppBins->getPhp()->isEnable()) {
+            $paths .= $bearsamppBins->getPhp()->getSymlinkPath() . ';';
+            $paths .= $bearsamppBins->getPhp()->getSymlinkPath() . '/pear;';
+            $paths .= $bearsamppBins->getPhp()->getSymlinkPath() . '/deps;';
+            $paths .= $bearsamppBins->getPhp()->getSymlinkPath() . '/imagick;';
+        }
+        if ($bearsamppBins->getNodejs()->isEnable()) {
+            $paths .= $bearsamppBins->getNodejs()->getSymlinkPath() . ';';
+        }
+        if ($bearsamppTools->getComposer()->isEnable()) {
+            $paths .= $bearsamppTools->getComposer()->getSymlinkPath() . ';';
+            $paths .= $bearsamppTools->getComposer()->getSymlinkPath() . '/vendor/bin;';
+        }
+        if ($bearsamppTools->getGhostscript()->isEnable()) {
+            $paths .= $bearsamppTools->getGhostscript()->getSymlinkPath() . '/bin;';
+        }
+        if ($bearsamppTools->getGit()->isEnable()) {
+            $paths .= $bearsamppTools->getGit()->getSymlinkPath() . '/bin;';
+        }
+        if ($bearsamppTools->getNgrok()->isEnable()) {
+            $paths .= $bearsamppTools->getNgrok()->getSymlinkPath() . ';';
+        }
+        if ($bearsamppTools->getPerl()->isEnable()) {
+            $paths .= $bearsamppTools->getPerl()->getSymlinkPath() . '/perl/site/bin;';
+            $paths .= $bearsamppTools->getPerl()->getSymlinkPath() . '/perl/bin;';
+            $paths .= $bearsamppTools->getPerl()->getSymlinkPath() . '/c/bin;';
+        }
+        if ($bearsamppTools->getPython()->isEnable()) {
+            $paths .= $bearsamppTools->getPython()->getSymlinkPath() . '/bin;';
+        }
+        if ($bearsamppTools->getRuby()->isEnable()) {
+            $paths .= $bearsamppTools->getRuby()->getSymlinkPath() . '/bin;';
+        }
+
+        return UtilPath::formatWindowsPath($paths);
+    }
+
+    /**
+     * Opens the given content in a temporary file using the system's default editor.
+     *
+     * @param   string  $caption  The caption/title for the temporary file.
+     * @param   string  $content  The content to write to the temporary file.
+     *
+     * @return void
+     */
+    public static function openFileContent($caption, $content)
+    {
+        global $bearsamppCore;
+
+        $tmpFile = $bearsamppCore->getTmpPath() . '/' . $caption . '.txt';
+        file_put_contents($tmpFile, $content);
+
+        // Open the file with the default editor
+        $bearsamppCore->getWinbinder()->exec('notepad.exe', $tmpFile);
+    }
+
+    /**
+     * Sets up cURL headers with token for API requests.
+     *
+     * @return array The array of cURL headers.
+     */
+    public static function setupCurlHeaderWithToken()
+    {
+        // Return empty array as token setup is no longer needed
+        return array();
     }
 }

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -2072,7 +2072,7 @@ class Util
     }
 
     /**
-     * Opens the given content in a temporary file using the system's default editor.
+     * Opens the given content in a temporary file using the editor configured in bearsampp.conf.
      *
      * @param   string  $caption  The caption/title for the temporary file.
      * @param   string  $content  The content to write to the temporary file.
@@ -2081,13 +2081,14 @@ class Util
      */
     public static function openFileContent($caption, $content)
     {
-        global $bearsamppCore;
+        global $bearsamppCore, $bearsamppConfig;
 
         $tmpFile = $bearsamppCore->getTmpPath() . '/' . $caption . '.txt';
         file_put_contents($tmpFile, $content);
 
-        // Open the file with the default editor
-        $bearsamppCore->getWinbinder()->exec('notepad.exe', $tmpFile);
+        // Open the file with the configured editor from bearsampp.conf
+        $editor = $bearsamppConfig->getNotepad();
+        $bearsamppCore->getWinbinder()->exec($editor, $tmpFile);
     }
 
     /**

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -2088,7 +2088,7 @@ class Util
 
         // Open the file with the configured editor from bearsampp.conf
         $editor = $bearsamppConfig->getNotepad();
-        $bearsamppCore->getWinbinder()->exec($editor, $tmpFile);
+        $bearsamppCore->getWinbinder()->exec($editor, '"' . $tmpFile . '"');
     }
 
     /**

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1925,38 +1925,39 @@ class Util
      * @return string|false The generated URL or false on invalid input.
      */
     public static function getGithubUrl($type = 'user', $user = 'Bearsampp', $repo = null, $branch = null, $path = null) {
-        // Basic validation
         if (empty($user) || !is_string($user)) {
             return false;
         }
-        
-        // URL-encode components to handle special characters
-        $user = urlencode($user);
-        
+
+        // Encode as URL path segment (not query encoding)
+        $user = rawurlencode($user);
+
         switch ($type) {
             case 'user':
                 return "https://github.com/{$user}";
-            
+
             case 'repo':
                 if (empty($repo) || !is_string($repo)) {
                     return false;
                 }
-                $repo = urlencode($repo);
+                $repo = rawurlencode($repo);
                 return "https://github.com/{$user}/{$repo}";
-            
+
             case 'raw':
                 if (empty($repo) || empty($branch) || empty($path) || !is_string($repo) || !is_string($branch) || !is_string($path)) {
                     return false;
                 }
-                $repo = urlencode($repo);
+                $repo = rawurlencode($repo);
                 $branch = rawurlencode($branch);
-                // Encode path segments individually to preserve slashes
+
+                $path = ltrim($path, '/');
                 $segments = array_map('rawurlencode', explode('/', $path));
                 $pathEncoded = implode('/', $segments);
+
                 return "https://raw.githubusercontent.com/{$user}/{$repo}/{$branch}/{$pathEncoded}";
 
             default:
-                return false; // Invalid type
+                return false;
         }
     }
 

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -333,11 +333,12 @@ class Util
     }
 
     /**
-     * Retrieves a list of version directories within a specified path.
+     * Gets the list of version directories in the specified path.
+     * Returns version suffixes by stripping the common prefix (basename of path) if present.
      *
-     * @param   string  $path  The path to search for version directories.
+     * @param   string  $path  The directory path to scan for version directories.
      *
-     * @return array|false Returns a sorted array of version names, or false if the directory cannot be opened.
+     * @return array|false Returns a sorted array of version suffixes, or false if the directory cannot be opened.
      */
     public static function getVersionList($path)
     {
@@ -348,10 +349,17 @@ class Util
             return false;
         }
 
+        $prefix = basename($path);
+
         while (false !== ($file = readdir($handle))) {
             $filePath = $path . '/' . $file;
             if ($file != '.' && $file != '..' && is_dir($filePath) && $file != 'current') {
-                $result[] = $file;
+                if (strpos($file, $prefix) === 0) {
+                    $version = substr($file, strlen($prefix));
+                } else {
+                    $version = $file;
+                }
+                $result[] = $version;
             }
         }
 

--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1949,10 +1949,12 @@ class Util
                     return false;
                 }
                 $repo = urlencode($repo);
-                $branch = urlencode($branch);
-                $path = urlencode($path);
-                return "https://raw.githubusercontent.com/{$user}/{$repo}/{$branch}/{$path}";
-            
+                $branch = rawurlencode($branch);
+                // Encode path segments individually to preserve slashes
+                $segments = array_map('rawurlencode', explode('/', $path));
+                $pathEncoded = implode('/', $segments);
+                return "https://raw.githubusercontent.com/{$user}/{$repo}/{$branch}/{$pathEncoded}";
+
             default:
                 return false; // Invalid type
         }
@@ -2095,7 +2097,10 @@ class Util
      */
     public static function setupCurlHeaderWithToken()
     {
-        // Return empty array as token setup is no longer needed
-        return array();
+        // Return headers with User-Agent, which is required by GitHub API
+        return array(
+            'User-Agent: ' . APP_GITHUB_USERAGENT . ' (https://github.com/' . APP_GITHUB_USER . '/' . APP_GITHUB_REPO . ')',
+            'Accept: application/vnd.github.v3+json'
+        );
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Consolidate GitHub URL generation into single parameterized method with validation

- Refactor version list retrieval to strip common prefix from directory names

- Simplify utility methods: folder listing, NSSM paths, file content viewer

- Fix GitHub raw URL encoding using rawurlencode for path segments

- Restore User-Agent and Accept headers required by GitHub API

- Add encoding conversion helper for UTF-8/Windows-1252 bidirectional conversion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub URL Methods"] -->|consolidate| B["getGithubUrl<br/>with type parameter"]
  C["Version List"] -->|strip prefix| D["Clean version suffixes"]
  E["Utility Methods"] -->|simplify| F["Folder listing<br/>NSSM paths<br/>File content"]
  G["URL Encoding"] -->|fix| H["rawurlencode<br/>path segments"]
  I["cURL Headers"] -->|restore| J["User-Agent<br/>Accept headers"]
  K["Encoding"] -->|add| L["convertEncoding<br/>helper method"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.util.php</strong><dd><code>Consolidate GitHub URLs and simplify utility methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.util.php

<ul><li>Consolidated GitHub URL generation into single <code>getGithubUrl()</code> method <br>supporting 'user', 'repo', and 'raw' types with proper validation and <br><code>rawurlencode</code> for path segments<br> <li> Refactored <code>getVersionList()</code> to strip common prefix (basename) from <br>directory names for cleaner version suffixes<br> <li> Simplified <code>getFolderList()</code> to return folder names directly with <br>natural case sorting<br> <li> Refactored <code>getNssmEnvPaths()</code> to build paths from enabled bins and <br>tools instead of reading from file<br> <li> Simplified <code>openFileContent()</code> to use configured editor from <br>bearsampp.conf instead of hardcoded notepad.exe<br> <li> Restored User-Agent and Accept headers in <code>setupCurlHeaderWithToken()</code> <br>required by GitHub API<br> <li> Added <code>convertEncoding()</code> helper method for bidirectional <br>UTF-8/Windows-1252 conversion<br> <li> Reordered <code>getWebsiteUrl()</code> and <code>getWebsiteUrlNoUtm()</code> methods for <br>improved code organization</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/210/files#diff-4cf3daa5765ea02c1921901194cf0cfb0786be4ce5b34673e7b6701e0bf37b46">+160/-166</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

