### PR TITLE
Remove unused getChangelogUrl utility method

### DIFF
--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -1172,18 +1172,6 @@ class Util
     }
 
     /**
-     * Constructs the URL to the changelog page, optionally including UTM parameters.
-     *
-     * @param   bool  $utmSource  Whether to include UTM source parameters.
-     *
-     * @return string The URL to the changelog page.
-     */
-    public static function getChangelogUrl($utmSource = true)
-    {
-        return self::getWebsiteUrl('doc/changelog', null, $utmSource);
-    }
-
-    /**
      * Retrieves the file size of a remote file.
      *
      * @param   string  $url            The URL of the remote file.


### PR DESCRIPTION
### **User description**
Fixes #211


___

### **PR Type**
Enhancement


___

### **Description**
- Remove unused `getChangelogUrl()` static method from utility class

- Simplifies codebase by eliminating dead code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["class.util.php"] -- "removes unused method" --> B["getChangelogUrl()"]
  B -- "was wrapping" --> C["getWebsiteUrl()"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.util.php</strong><dd><code>Remove unused getChangelogUrl static method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.util.php

<ul><li>Removed unused <code>getChangelogUrl()</code> static method that wrapped <br><code>getWebsiteUrl()</code><br> <li> Deleted associated PHPDoc comment block documenting the method<br> <li> No functional impact as method was not being called elsewhere</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/220/files#diff-4cf3daa5765ea02c1921901194cf0cfb0786be4ce5b34673e7b6701e0bf37b46">+0/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

