### PR TITLE
Migrate homepage path methods from Homepage class to Path class for better organization

### DIFF
--- a/core/classes/bins/class.bin.apache.php
+++ b/core/classes/bins/class.bin.apache.php
@@ -230,7 +230,7 @@ class BinApache extends Module
      */
     public function checkPort($port, $ssl = false, $showWindow = false)
     {
-        global $bearsamppLang, $bearsamppWinbinder, $bearsamppHomepage;
+        global $bearsamppLang, $bearsamppWinbinder;
         $boxTitle = sprintf( $bearsamppLang->getValue( Lang::CHECK_PORT_TITLE ), $this->getName(), $port );
 
         if ( !Util::isValidPort( $port ) ) {
@@ -239,7 +239,7 @@ class BinApache extends Module
             return false;
         }
 
-        $headers = HttpClient::getHttpHeaders( 'http' . ($ssl ? 's' : '') . '://localhost:' . $port . '/' . $bearsamppHomepage->getWebResourcesPath() . '/ping.php' );
+        $headers = HttpClient::getHttpHeaders( 'http' . ($ssl ? 's' : '') . '://localhost:' . $port . '/' . Path::getWebResourcesPath() . '/ping.php' );
         if ( !empty( $headers ) ) {
             foreach ( $headers as $row ) {
                 if ( UtilString::startWith( $row, 'Server: ' ) || UtilString::startWith( $row, 'server: ' ) ) {

--- a/core/classes/class.homepage.php
+++ b/core/classes/class.homepage.php
@@ -83,59 +83,6 @@ class Homepage
     }
 
     /**
-     * Gets the path to the homepage directory.
-     *
-     * @return string The homepage directory path.
-     */
-    public function getWebHomepagePath()
-    {
-        global $bearsamppCore;
-        return Path::getResourcesPath(false) . '/homepage';
-    }
-
-    /**
-     * Gets the path to the images directory.
-     *
-     * @return string The images directory path.
-     */
-    public function getWebImagesPath()
-    {
-        return $this->getWebResourcesPath() . '/img/';
-    }
-
-    /**
-     * Gets the path to the icons directory.
-     *
-     * @return string The icons directory path.
-     */
-    public function getWebIconsPath()
-    {
-        return $this->getWebResourcesPath() . '/img/icons/';
-    }
-
-    /**
-     * Gets the path to the resources directory.
-     *
-     * @return string The resources directory path.
-     */
-    public function getWebResourcesPath()
-    {
-        global $bearsamppCore;
-        return md5(APP_TITLE);
-    }
-
-    /**
-     * Gets the URL to the resources directory.
-     *
-     * @return string The resources directory URL.
-     */
-    public function getResourcesUrl()
-    {
-        global $bearsamppRoot;
-        return $bearsamppRoot->getLocalUrl($this->getWebResourcesPath());
-    }
-
-    /**
      * Refreshes the alias content by updating the alias configuration file.
      *
      * @return bool True if the alias content was successfully refreshed, false otherwise.
@@ -145,11 +92,11 @@ class Homepage
         global $bearsamppBins;
 
         $result = $bearsamppBins->getApache()->getAliasContent(
-            $this->getWebResourcesPath(),
-            $this->getWebHomepagePath()
+            Path::getWebResourcesPath(),
+            Path::getHomepagePath()
         );
 
-        return file_put_contents($this->getWebHomepagePath() . '/alias.conf', $result) !== false;
+        return file_put_contents(Path::getHomepagePath() . '/alias.conf', $result) !== false;
     }
 
     /**
@@ -157,10 +104,9 @@ class Homepage
      */
     public function refreshCommonsJsContent()
     {
-        Util::replaceInFile($this->getWebHomepagePath() . '/js/_commons.js', array(
-            '/^\s\surl:.*/' => '  url: "' . $this->getWebResourcesPath() . '/ajax.php"',
-            '/AJAX_URL.*=.*/' => 'const AJAX_URL = "' . $this->getWebResourcesPath() . '/ajax.php"',
+        Util::replaceInFile(Path::getHomepagePath() . '/js/_commons.js', array(
+            '/^\s\surl:.*/' => '  url: "' . Path::getWebResourcesPath() . '/ajax.php"',
+            '/AJAX_URL.*=.*/' => 'const AJAX_URL = "' . Path::getWebResourcesPath() . '/ajax.php"',
         ));
     }
 }
-

--- a/core/classes/class.path.php
+++ b/core/classes/class.path.php
@@ -226,6 +226,47 @@ class Path
     }
 
     /**
+     * Retrieves the web resources path.
+     *
+     * @return string The web resources path.
+     */
+    public static function getWebResourcesPath()
+    {
+        return rtrim(md5(APP_TITLE), '/');
+    }
+
+    /**
+     * Retrieves the web images path.
+     *
+     * @return string The web images path.
+     */
+    public static function getWebImagesPath()
+    {
+        return self::getWebResourcesPath() . '/img';
+    }
+
+    /**
+     * Retrieves the web icons path.
+     *
+     * @return string The web icons path.
+     */
+    public static function getWebIconsPath()
+    {
+        return self::getWebImagesPath() . '/icons';
+    }
+
+    /**
+     * Retrieves the URL to the web resources.
+     *
+     * @return string The web resources URL.
+     */
+    public static function getWebResourcesUrl()
+    {
+        global $bearsamppRoot;
+        return $bearsamppRoot->getLocalUrl(self::getWebResourcesPath());
+    }
+
+    /**
      * Retrieves the path to the scripts.
      *
      * @param   bool  $aetrayPath  Whether to format the path for AeTrayMenu.

--- a/core/resources/homepage/homepage.php
+++ b/core/resources/homepage/homepage.php
@@ -41,15 +41,15 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-i
 global $bearsamppLang, $bearsamppCore, $bearsamppHomepage, $bearsamppConfig, $bearsamppRoot;
 
 /**
- * Set the base path for resources, ensuring there is a trailing slash.
+ * Set the base path for resources, ensuring there is NO trailing slash.
  */
-$resourcesPath = rtrim( $bearsamppHomepage->getWebResourcesPath(), '/' ) . '/';
+$resourcesPath = Path::getWebResourcesPath();
 
 /**
  * Define paths for icons and images used in the homepage.
  */
-$iconsPath  = $bearsamppHomepage->getWebIconsPath();
-$imagesPath = $bearsamppHomepage->getWebImagesPath();
+$iconsPath  = $resourcesPath . '/img/icons/';
+$imagesPath = $resourcesPath . '/img/';
 
 // Instantiate the QuickPick class
 $quickPick = new QuickPick();
@@ -113,7 +113,7 @@ $getLoader = '<span class = "loader float-end"><img src = "' . $imagesPath . 'lo
      * Loop through CSS files and include them in the page.
      */
     foreach ( $cssFiles as $file ) {
-        echo '<link href="' . $resourcesPath . $file . '" rel="stylesheet">' . PHP_EOL;
+        echo '<link href="' . $resourcesPath . '/' . ltrim($file, '/') . '" rel="stylesheet">' . PHP_EOL;
     }
     ?>
 
@@ -222,9 +222,8 @@ $getLoader = '<span class = "loader float-end"><img src = "' . $imagesPath . 'lo
 
 <?php
 foreach ( $jsFiles as $file ) {
-    echo '<script src="' . $resourcesPath . $file . '"></script>' . PHP_EOL;
+    echo '<script src="' . $resourcesPath . '/' . ltrim($file, '/') . '"></script>' . PHP_EOL;
 }
 ?>
 </body>
 </html>
-

--- a/core/root.php
+++ b/core/root.php
@@ -24,11 +24,9 @@ const QUICKPICK_API_KEY = '4abe15e5-95f2-4663-ad12-eadb245b28b4';
 const QUICKPICK_API_URL = 'https://bearsampp.com/index.php?option=com_osmembership&task=api.get_active_plan_ids&api_key=';
 
 // URL where quickpick-releases.json lives
-const QUICKPICK_JSON_URL = 'https://raw.githubusercontent.com/Bearsampp/Bearsampp/main/core/resources/quickpick-releases.json';
+const QUICKPICK_JSON_URL = 'https://raw.githubusercontent.com/' . APP_GITHUB_USER . '/' . APP_GITHUB_REPO . '/main/core/resources/quickpick-releases.json';
 
-/**
- * CRITICAL: Check for elevation IMMEDIATELY - must be FAST to minimize console window visibility
- */
+// CRITICAL: Check for elevation IMMEDIATELY - must be FAST to minimize console window visibility
 if (isset($_SERVER['argv']) && isset($_SERVER['argv'][1]) && $_SERVER['argv'][1] === 'startup') {
     $flagFile = sys_get_temp_dir() . '/bearsampp_no_admin.lock';
 
@@ -167,4 +165,3 @@ if ($bearsamppRoot->isRoot()) {
  */
 global $bearsamppLang;
 $locale = $bearsamppLang->getValue('locale');
-


### PR DESCRIPTION
### **PR Type**
Enhancement, Refactoring


___

### **Description**
- Migrate path methods from Homepage to Path class for better organization

- Remove trailing slashes from web resource paths for consistency

- Update all references throughout codebase to use Path static methods

- Refactor QUICKPICK_JSON_URL to use dynamic GitHub constants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Homepage Class<br/>Path Methods"] -->|"Migrate"| B["Path Class<br/>Static Methods"]
  B -->|"Used by"| C["Homepage.php<br/>Resource Paths"]
  B -->|"Used by"| D["Apache Class<br/>Port Check"]
  E["Hardcoded GitHub URL"] -->|"Replace with"| F["Dynamic Constants<br/>APP_GITHUB_USER/REPO"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.bin.apache.php</strong><dd><code>Update to use Path class methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/bins/class.bin.apache.php

<ul><li>Remove unused <code>$bearsamppHomepage</code> global variable<br> <li> Replace <code>$bearsamppHomepage->getWebResourcesPath()</code> with <br><code>Path::getWebResourcesPath()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/227/files#diff-bee0ab8e8b6bfb3bd8a3fc0aa18bbfc3809e52af669fb34a6dc196d2e1c30726">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class.homepage.php</strong><dd><code>Remove path methods, migrate to Path class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.homepage.php

<ul><li>Remove five path methods: <code>getWebHomepagePath()</code>, <code>getWebImagesPath()</code>, <br><code>getWebIconsPath()</code>, <code>getWebResourcesPath()</code>, <code>getResourcesUrl()</code><br> <li> Update <code>refreshAliasContent()</code> to use <code>Path::getWebResourcesPath()</code> and <br><code>Path::getHomepagePath()</code><br> <li> Update <code>refreshCommonsJsContent()</code> to use Path class methods instead of <br>instance methods</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/227/files#diff-a92f1e96c54ed4002f0bcb3b4c181b5c5d0bf9c8ee70a6d5d1f099ee321aa91a">+6/-60</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>homepage.php</strong><dd><code>Refactor resource paths and fix concatenation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/resources/homepage/homepage.php

<ul><li>Change <code>$resourcesPath</code> to use <code>Path::getWebResourcesPath()</code> without <br>trailing slash<br> <li> Update <code>$iconsPath</code> and <code>$imagesPath</code> to construct paths from <br><code>$resourcesPath</code><br> <li> Fix CSS and JavaScript file path concatenation with proper slash <br>handling using <code>ltrim()</code><br> <li> Update documentation comment to reflect no trailing slash requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/227/files#diff-6cc98c81a488b7ab55165d28cb3ad20a7f60cb1d4edcf2d97d889b99a3f4aae0">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class.path.php</strong><dd><code>Add web path methods as static methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/classes/class.path.php

<ul><li>Add <code>getWebResourcesPath()</code> static method returning MD5 hash without <br>trailing slash<br> <li> Add <code>getWebImagesPath()</code> static method for web images directory<br> <li> Add <code>getWebIconsPath()</code> static method for web icons directory<br> <li> Add <code>getWebResourcesUrl()</code> static method for resources URL</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/227/files#diff-f7194911cf65ec5b9564e8536e5c9467e3f9dc6a2860746e03c04b92974fbe75">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>root.php</strong><dd><code>Use dynamic constants for GitHub URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/root.php

<ul><li>Replace hardcoded GitHub URL in <code>QUICKPICK_JSON_URL</code> with dynamic <br>constants <code>APP_GITHUB_USER</code> and <code>APP_GITHUB_REPO</code><br> <li> Convert multi-line comment to single-line comment for elevation check<br> <li> Remove trailing blank line at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/sandbox/pull/227/files#diff-d7a84304000fa822691d765ae105209eb793fa5075db7ae66f8ab7ee9c8f4bcc">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

